### PR TITLE
bin/compile fails when called manually and there's no cache

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,6 +45,7 @@ else
     curl -sO $url
     tar zxf $file
     rm -f $file
+    cd ../../..
     echo " done"
 fi
 


### PR DESCRIPTION
`bin/compile` complains that it can't find the vendored `virtualenv.py` file, because it uses a relative path (`$buildpack`) and the code installing Go changes the current dir.
