### PR TITLE
File copy bug

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -52,7 +52,6 @@ GOROOT=$cache/go-$ver/go export GOROOT
 GOPATH=$build/.heroku/g export GOPATH
 PATH=$GOROOT/bin:$PATH
 
-
 if ! (which hg > /dev/null && which bzr > /dev/null)
 then
     echo -n "       Installing Virtualenv..."
@@ -72,7 +71,7 @@ fi
 name=$(cat $build/.godir)
 p=$GOPATH/src/$name
 mkdir -p $p
-cp -R $build/* $p
+cp -R $build/src/$name/* $p
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
 echo "-----> Running: go get ./..."


### PR DESCRIPTION
The build pack was copying the contents of `$GOPATH` to
`$p/src/demoapp` causing the resulting directory structure
to look something like:

```
$GOPATH/src/demoapp/src/demoapp
```

This was causing local package imports to fail.  E.g. if I have
a directory "models" that defines a package models then I should be
able to import it via "demoapp/models" but the extra path addition
caused it to fail to find that directory.
