### PR TITLE
Adding more debug information in the compile phase

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -48,9 +48,13 @@ else
     echo " done"
 fi
 
+echo "-----> Setting up ENV variables"
 GOROOT=$cache/go-$ver/go export GOROOT
 GOPATH=$build/.heroku/g export GOPATH
 PATH=$GOROOT/bin:$PATH
+echo "       GOROOT=$GOROOT"
+echo "       GOPATH=$GOPATH"
+echo "       PATH=$PATH"
 
 
 if ! (which hg > /dev/null && which bzr > /dev/null)
@@ -69,10 +73,14 @@ then
     echo " done"
 fi
 
+echo "-----> Setting up the directory structure"
 name=$(cat $build/.godir)
 p=$GOPATH/src/$name
+echo "       Creating directory $p" 
 mkdir -p $p
 cp -R $build/* $p
+echo "       Copied [`ls -m $p`] into the GOPATH/src directory"
+
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
 echo "-----> Running: go get -tags heroku ./..."
@@ -84,4 +92,5 @@ mv $GOPATH/bin/* $build/bin
 rm -rf $build/.heroku
 
 mkdir -p $build/.profile.d
+
 echo 'export PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh


### PR DESCRIPTION
After trying to release a heroku go front end that was not trivial I found myself really needing a little bit more debug information out of the buildpack.

Here's a sample output with this change:

```
$ git subtree push --prefix src heroku master
...
-----> Fetching custom git buildpack... done
-----> Go app detected
-----> Using Go 1.0.3
-----> Setting up ENV variables
       GOROOT=/app/tmp/repo.git/.cache/go-1.0.3/go
       GOPATH=/tmp/build_2j4auww7lp5gu/.heroku/g
       PATH=/app/tmp/repo.git/.cache/go-1.0.3/go/bin:/app/tmp/repo.git/.cache/venv/bin::/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin
-----> Setting up the directory structure
       Creating directory /tmp/build_2j4auww7lp5gu/.heroku/g/src/
       Copied [Procfile, okvivi] into the GOPATH/src directory
-----> Running: go get -tags heroku ./...
-----> Discovering process types
       Procfile declares types -> web

-----> Compiled slug size: 1.0MB
-----> Launching... done, v10
       http://gofe-example.herokuapp.com deployed to Heroku
```

This is after pushing this Go server example that's not trivial anymore and involves a directory structure that's closer to real usage of Go, with multiple packages: https://github.com/okvivi/go-server-on-heroku
