### PR TITLE
add a PATH to release config_vars

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # bin/release <build-dir>
 
-echo "--- {}"
+cat <<EOF
+---
+config_vars:
+  PATH: bin:/usr/local/bin:/usr/bin:/bin
+EOF


### PR DESCRIPTION
Most buildpacks provide a basic PATH for the execution environment.
