### PR TITLE
Update the getting started link

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ virtualenv() {
 if ! test -f $build/.godir
 then
     echo >&2 " !     A .godir is required. For instructions:"
-    echo >&2 " !     http://mmcgrana.github.com/2012/09/getting-started-with-go-on-heroku"
+    echo >&2 " !     http://mmcgrana.github.io/2012/09/getting-started-with-go-on-heroku"
     exit 1
 fi
 


### PR DESCRIPTION
Github pages moved to the `.io` TLD.
