### PR TITLE
Allow setting git version at build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,24 @@ build [gopgsqldriver](https://github.com/jbarham/gopgsqldriver), add
 the config var `CGO_CFLAGS` with the value
 `-I/app/code/vendor/include/postgresql` and include the relevant
 Postgres header files in `vendor/include/postgresql/` in your app.
+
+## Setting the version at build time
+
+If you set the `GO_GIT_DESCRIBE_SYMBOL` to the name of a string variable, it
+will be set at build time to the output of `git describe --tags`, if any. This
+is useful for setting the version at build time, for example, in your `main.go`:
+
+```go
+package main
+
+var version string
+```
+
+To set this variable at build time, you would need to do the following:
+
+```bash
+heroku config:set GO_GIT_DESCRIBE_SYMBOL=main.version
+
+git tag 1.2.3
+git push heroku 1.2.3
+```

--- a/bin/compile
+++ b/bin/compile
@@ -142,12 +142,6 @@ then
     done
 fi
 
-# Allow passing extra ldflags to go install. To use this,
-# 1. Set the `GO_GIT_DESCRIBE_SYMBOL` to point to the variable name that you
-# want to set at build time, e.g. run:
-#   heroku config:set GO_GIT_DESCRIBE_SYMBOL=main.version
-# 2. Don't forget to push tags to heroku:
-#   git tag 2.0.1 && git push heroku 2.0.1
 FLAGS=(-tags heroku)
 if test -f "$env_dir/GO_GIT_DESCRIBE_SYMBOL"
 then


### PR DESCRIPTION
I want to pass a flag to `go install`, e.g.

```
godep go install -tags heroku -ldflags "-X main.version $(git --git-dir=$(HEROKU_GIT_DIR) describe)"
```

I can't do this with only using environment variables, since the point here is to pass in compile time flags that potentially change at every compilation. Another example would be passing in the build time.

If there is another way to do this with the upstream buildpack, please let me know. If you think there is a better solution than a raw `Makefile`, I'm open to suggestions.

I have not added any documentation or test cases for this, as I wanted to get some feedback first.
