### PR TITLE
Only do the symlink if envdir is passed in and you're setting this stuff

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -129,10 +129,10 @@ mkdir -p $p
 cp -R $build/* $p
 
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
-ln -s $build /app/code
 env_dir="$3"
 if [ -d "$env_dir" ]
 then
+    ln -s $build /app/code
     for cgo_opt in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS
     do
         if [ -f "$env_dir/$cgo_opt" ]


### PR DESCRIPTION
As it is now we can't use this buildpack in non dyno environments w/o
/app
