### PR TITLE
Check for godeps or godir instead of .go

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -103,7 +103,7 @@ GOPATH=$build/.heroku/g export GOPATH
 PATH=$GOROOT/bin:$PATH
 
 
-if ! (test -d $build/Godeps || (which hg >/dev/null && which bzr >/dev/null))
+if ! (test -e $build/Godeps || (which hg >/dev/null && which bzr >/dev/null))
 then
     echo
     echo "       Tired of waiting for bzr and hg?"
@@ -152,6 +152,13 @@ fi
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
 cd $p
+
+if test -f $build/Godeps
+then
+    echo "-----> Running: godep restore"
+    godep restore
+fi
+
 if test -e $build/Godeps
 then
     echo "-----> Running: godep go install ${FLAGS[@]} ./..."

--- a/bin/detect
+++ b/bin/detect
@@ -2,7 +2,10 @@
 # bin/detect <build-dir>
 set -e
 
-if test -n "$(find "$1" -type f -name '*.go' | sed 1q)"
+BUILD_DIR=$1
+
+# Do we have a godeps file or directory?
+if test -e $BUILD_DIR/Godeps || test -f $BUILD_DIR/.godir
 then echo Go
 else echo no; exit 1
 fi


### PR DESCRIPTION
I'm working on a project with no .go files in the root and still wanted to use the buildpack, minor tweaks for that.

Separately I didn't want to include all my deps in my repo, (via godep save -copy=false ./...) and this supports that.

Awesome project, thanks!
