### PR TITLE
Use Go 1.4 when Godep is not present

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ then
 elif test -f $build/.godir
 then
     name=$(cat $build/.godir)
-    ver=go${GOVERSION:-1.3}
+    ver=go${GOVERSION:-1.4}
 else
     echo >&2 " !     A .godir is required. For instructions:"
     echo >&2 " !     http://mmcgrana.github.io/2012/09/getting-started-with-go-on-heroku"


### PR DESCRIPTION
This only affects apps that do not use godep.
