### PR TITLE
Set a string via -ldflags at compile time

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,16 @@ to, e.g., specify paths for vendored dependencies. E.g., to build
 `CGO_CFLAGS` with the value `-I/app/code/vendor/include/postgresql` and include
 the relevant Postgres header files in `vendor/include/postgresql/` in your app.
 
+## Passing a symbol (and optional string) to the linker
+
+This buildpack supports the go [linker's][go-linker] ability (`-X symbol
+value`) to set the value of a string at link time. This can be done by setting
+`GO_LINKER_SYMBOL` and `GO_LINKER_VALUE` in the application's config before
+pushing code.
+
 [go]: http://golang.org/
 [buildpack]: http://devcenter.heroku.com/articles/buildpacks
+[go-linker]: https://golang.org/cmd/ld/
 [godep]: https://github.com/tools/godep
 [quickstart]: http://mmcgrana.github.com/2012/09/getting-started-with-go-on-heroku.html
 [build-constraint]: http://golang.org/pkg/go/build/

--- a/bin/compile
+++ b/bin/compile
@@ -157,10 +157,10 @@ unset GIT_DIR # unset git dir or it will mess with goinstall
 cd $p
 if test -e $build/Godeps
 then
-    echo "-----> Running: godep go install -tags heroku ./..."
+    echo "-----> Running: godep go install ${FLAGS[@]} ./..."
     godep go install "${FLAGS[@]}" ./...
 else
-    echo "-----> Running: go get -tags heroku ./..."
+    echo "-----> Running: go get ${FLAGS[@]} ./..."
     go get "${FLAGS[@]}" ./...
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -129,9 +129,6 @@ p=$GOPATH/src/$name
 mkdir -p $p
 cp -R $build/* $p
 
-# Default to $VERSION environment variable
-GO_LINKER_VALUE=${VERSION}
-
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
 env_dir="$3"
 if [ -d "$env_dir" ]

--- a/bin/compile
+++ b/bin/compile
@@ -129,12 +129,15 @@ p=$GOPATH/src/$name
 mkdir -p $p
 cp -R $build/* $p
 
+# Default to $VERSION environment variable
+GO_LINKER_VALUE=${VERSION}
+
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
 env_dir="$3"
 if [ -d "$env_dir" ]
 then
     ln -sfn $build /app/code
-    for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS
+  for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GO_LINKER_SYMBOL GO_LINKER_VALUE
     do
         if [ -f "$env_dir/$key" ]
         then
@@ -143,15 +146,22 @@ then
     done
 fi
 
+# If $GO_LINKER_SYMBOL and GO_LINKER_VALUE are set, tell the linker to DTRT
+FLAGS=(-tags heroku)
+if [ -n "$GO_LINKER_SYMBOL" -a -n "$GO_LINKER_VALUE" ]
+then
+  FLAGS=(${FLAGS[@]} -ldflags "-X $GO_LINKER_SYMBOL $GO_LINKER_VALUE")
+fi
+
 unset GIT_DIR # unset git dir or it will mess with goinstall
 cd $p
 if test -e $build/Godeps
 then
     echo "-----> Running: godep go install -tags heroku ./..."
-    godep go install -tags heroku ./...
+    godep go install "${FLAGS[@]}" ./...
 else
     echo "-----> Running: go get -tags heroku ./..."
-    go get -tags heroku ./...
+    go get "${FLAGS[@]}" ./...
 fi
 
 rm -rf $build/.heroku


### PR DESCRIPTION
if `$GO_LINKER_SYMBOL` and `$GO_LINKER_VALUE` is set in the application's
config bin/compile will set
`-ldflags "-X $GO_LINKER_SYMBOL $GO_LINKER_VALUE"`
 when building the binaries.

If the application sets `$GO_LINKER_SYMBOL`, but not `$GO_LINKER_VALUE`
bin/compile will set `$GO_LINKER_VALUE` to the `$VERSION` that is exposed by
the **build environment**. For git deploys `$VERSION` should be set to `$(git
describe --tags --always)` by Heroku's build environment. 

**Note**: The build environment does not as of yet set `$VERSION`.

The typical use case is to embed the git tag/sha into the compiled
binaries. This would be done by specifying a `$GO_LINKER_SYMBOL` of
`main.version` and then in your main package define the following:

```go
package main

var version string

...
```

You can find more info here: https://golang.org/cmd/ld/

/cc @tt 

Should close #5 