### PR TITLE
Add a way to run commands after compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -153,6 +153,12 @@ else
     go get -tags heroku ./...
 fi
 
+if test -f "$env_dir/POST_BUILD_COMMAND"
+then
+    echo "-----> Running: $(cat $env_dir/POST_BUILD_COMMAND)"
+    source "$env_dir/POST_BUILD_COMMAND"
+fi
+
 rm -rf $build/.heroku
 
 mkdir -p $build/.profile.d

--- a/bin/compile
+++ b/bin/compile
@@ -155,8 +155,12 @@ fi
 
 if test -f "$env_dir/POST_BUILD_COMMAND"
 then
-    echo "-----> Running: $(cat $env_dir/POST_BUILD_COMMAND)"
-    source "$env_dir/POST_BUILD_COMMAND"
+    for key in "$env_dir"/*
+    do
+        ENV="$ENV $(basename $key)=\"$(cat $key)\""
+    done
+    echo "-----> Running: $(cat "$env_dir"/POST_BUILD_COMMAND)"
+    eval "$ENV $(cat "$env_dir"/POST_BUILD_COMMAND)"
 fi
 
 rm -rf $build/.heroku


### PR DESCRIPTION
This is useful e.g. for running migrations, when the tools required are not going to be built (e.g. because they are vendored in `Godeps`).

`POST_BUILD_COMMAND` can be something simple, or it can point to a script inside the repo.

Here's an example post-install script:

``` sh
export PATH="$PATH:$(godep path)/bin"
godep go install github.com/some/vendored/cmd/migrate
migrate -env=heroku
```

---

I am of course open to suggestions, if there's a better way to do this, however this seemed to be the simplest solution.
