### PR TITLE
Use `SOURCE_VERSION`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -129,6 +129,9 @@ p=$GOPATH/src/$name
 mkdir -p $p
 cp -R $build/* $p
 
+# Default to $SOURCE_VERSION environment variable
+GO_LINKER_VALUE=${SOURCE_VERSION}
+
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
 env_dir="$3"
 if [ -d "$env_dir" ]


### PR DESCRIPTION
This defaults to the `SOURCE_VERSION` environment variable which is now available in the build environment.