### PR TITLE
Use the canonical import path if defined

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -35,6 +35,8 @@ urlfor() {
     esac
 }
 
+DEFAULT_GOVERSION=1.4.2
+
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
@@ -55,6 +57,21 @@ virtualenv() {
     python "$buildpack/vendor/virtualenv-1.11.6/virtualenv.py" "$@"
 }
 
+echo_urls() {
+  warn "https://medium.com/@freeformz/hello-world-with-go-heroku-38295332f07b"
+  warn "or http://tip.golang.org/doc/go1.4#canonicalimports"
+}
+
+abort_required() {
+  warn "Godeps or a canonical import path are required. For instructions:"
+  echo_urls
+  exit 1
+}
+
+warn() {
+  echo >&2 " !      $1"
+}
+
 if test -f $build/Godeps
 then
     name=$(<$build/Godeps jq -r .ImportPath)
@@ -65,12 +82,21 @@ then
     ver=$(<$build/Godeps/Godeps.json jq -r .GoVersion)
 elif test -f $build/.godir
 then
+    warn "WARNING: .godir is deprecated and will be removed."
+    warn "Please use godeps or a canonical import path. For instructions:"
+    echo_urls
     name=$(cat $build/.godir)
-    ver=go${GOVERSION:-1.4.2}
+    ver=go${GOVERSION:-$DEFAULT_GOVERSION}
+elif go list -f {{.ImportComment}}
+then
+    name=$(go list -f {{.ImportComment}})
+    ver=go${GOVERSION:-$DEFAULT_GOVERSION}
+    if test -z "$name"
+    then
+      abort_required
+    fi
 else
-    echo >&2 " !     Godeps are required. For instructions:"
-    echo >&2 " !     https://medium.com/@freeformz/hello-world-with-go-heroku-38295332f07b"
-    exit 1
+  abort_required
 fi
 
 file=${GOFILE:-$ver.$(uname|tr A-Z a-z)-amd64$(platext $ver).tar.gz}
@@ -78,7 +104,7 @@ url=${GOURL:-$(urlfor $ver $file)}
 
 if test -e $build/bin && ! test -d $build/bin
 then
-    echo >&2 " !     File bin exists and is not a directory."
+    warn "File bin exists and is not a directory."
     exit 1
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -62,12 +62,6 @@ echo_urls() {
   warn "or http://tip.golang.org/doc/go1.4#canonicalimports"
 }
 
-abort_required() {
-  warn "Godeps or a canonical import path are required. For instructions:"
-  echo_urls
-  exit 1
-}
-
 warn() {
   echo >&2 " !      $1"
 }
@@ -87,16 +81,14 @@ then
     echo_urls
     name=$(cat $build/.godir)
     ver=go${GOVERSION:-$DEFAULT_GOVERSION}
-elif go list -f {{.ImportComment}}
+elif test ! -z "$(go list -f {{.ImportComment}} 2>/dev/null)"
 then
     name=$(go list -f {{.ImportComment}})
     ver=go${GOVERSION:-$DEFAULT_GOVERSION}
-    if test -z "$name"
-    then
-      abort_required
-    fi
 else
-  abort_required
+  warn "Godeps or a canonical import path are required. For instructions:"
+  echo_urls
+  exit 1
 fi
 
 file=${GOFILE:-$ver.$(uname|tr A-Z a-z)-amd64$(platext $ver).tar.gz}


### PR DESCRIPTION
This allows us to use a go standard to define the path for the code
instead of relying on `.godir`.

/cc #63 
