### PR TITLE
use new linker -X option format for go1.5

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -204,7 +204,15 @@ fi
 FLAGS=(-tags heroku)
 if [ -n "$GO_LINKER_SYMBOL" -a -n "$GO_LINKER_VALUE" ]
 then
-  FLAGS=(${FLAGS[@]} -ldflags "-X $GO_LINKER_SYMBOL $GO_LINKER_VALUE")
+  case $ver in
+  go1.5*)
+    xval="$GO_LINKER_SYMBOL=$GO_LINKER_VALUE"
+    ;;
+  *)
+    xval="$GO_LINKER_SYMBOL $GO_LINKER_VALUE"
+    ;;
+  esac
+  FLAGS=(${FLAGS[@]} -ldflags "-X $xval")
 fi
 
 unset GIT_DIR # unset git dir or it will mess with goinstall


### PR DESCRIPTION
Silences warning.

Tested with go1.4.2:

```
remote: -----> Fetching custom git buildpack... done
remote: -----> Go app detected
remote: -----> Checking Godeps/Godeps.json file.
remote: -----> Installing go1.4.2... done
remote: -----> Running: godep go install -tags heroku -ldflags -X github.com/heroku/shaas/config.version 2bf616344b3e9d1b2f4e8ca25b7b3f4ed369da1b ./...
```

and go1.5.1:

```
remote: -----> Fetching custom git buildpack... done
remote: -----> Go app detected
remote: -----> Checking Godeps/Godeps.json file.
remote: -----> Using go1.5.1
remote: -----> Running: godep go install -tags heroku -ldflags -X github.com/heroku/shaas/config.version=71840bacaff64d869d9b5d12f269f65faecadd4a ./...
```
