### PR TITLE
Deprecate older go versions, .godir & Godeps file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,20 +3,8 @@
 
 set -eo pipefail
 
-# Go releases for Darwin beginning with 1.2rc1
-# have included more than one build, depending
-# on the specific version of Mac OS X. Try to
-# account for that, but don't try too hard.
-# This doesn't affect Heroku builds, it's only
-# for testing on Darwin systems.
-platext() {
-    case $1 in
-    go1.0*|go1.1beta*|go1.1rc*|go1.1|go1.1.*) return ;;
-    esac
-    case $(uname|tr A-Z a-z) in
-    darwin) printf %s -osx10.8 ;;
-    esac
-}
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
 
 # Go releases have moved to a new URL scheme
 # starting with Go version 1.2.2. Return the old
@@ -33,6 +21,38 @@ urlfor() {
         echo https://storage.googleapis.com/golang/$file
         ;;
     esac
+}
+
+# Expand to supported versions of Go, (e.g. expand "go1.5" to latest release go1.5.2)
+# All specific or other versions, take as is.
+expand_ver() {
+  case $1 in
+    go1.5)
+      echo "go1.5.2"
+      ;;
+    go1.4)
+      echo "go1.4.3"
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+
+# Report deprecated versions to user
+# Use after expand_ver
+report_ver() {
+  case $1 in
+    go1.5.2|go1.4.3)
+      # Noop
+    ;;
+    *)
+      warn ""
+      warn "Deprecated version of go ($1)"
+      warn "See https://devcenter.heroku.com/articles/go-support#go-versions for supported version information."
+      warn ""
+    ;;
+  esac
 }
 
 mkdir -p "$1" "$2"
@@ -57,7 +77,7 @@ virtualenv() {
 }
 
 warn() {
-    echo >&2 " !     $@"
+    echo -e >&2 "${YELLOW} !     $@${NC}"
 }
 
 step() {
@@ -74,9 +94,16 @@ finished() {
 
 if test -f $build/Godeps
 then
+    warn ""
     warn "Deprecated, old ./Godeps file found!"
+    warn ""
+    warn "Support for this old version of Godeps is ending on 2016/02/01"
+    warn ""
     warn "Please upgrade godeps (go get -u github.com/tools/godep) and"
     warn "re-save your dependencies: godep save -r ./..."
+    warn ""
+    warn "See also: https://devcenter.heroku.com/articles/go-dependencies-via-godep"
+    warn ""
     name=$(<$build/Godeps jq -r .ImportPath)
     ver=$(<$build/Godeps jq -r .GoVersion)
 elif test -f $build/Godeps/Godeps.json
@@ -91,8 +118,12 @@ then
     ver=$(<$build/Godeps/Godeps.json jq -r .GoVersion)
 elif test -f $build/.godir
 then
+    warn ""
     warn "Deprecated, .godir file found!"
-    warn "Please switch to godeps (github.com/tools/godep) ASAP"
+    warn ""
+    warn "Support for .godir is ending on 2016/02/01"
+    warn "See also: https://devcenter.heroku.com/articles/go-dependencies-via-godep"
+    warn ""
     name=$(cat $build/.godir)
     ver=go${GOVERSION:-1.5}
 else
@@ -101,14 +132,20 @@ else
     exit 1
 fi
 
-file=${GOFILE:-$ver.$(uname|tr A-Z a-z)-amd64$(platext $ver).tar.gz}
+ver=$(expand_ver $ver)
+
+file=${GOFILE:-$ver.linux-amd64.tar.gz}
 url=${GOURL:-$(urlfor $ver $file)}
 
 if test -e $build/bin && ! test -d $build/bin
 then
+    warn ""
     warn "File bin exists and is not a directory."
+    warn ""
     exit 1
 fi
+
+report_ver $ver
 
 if test -d $cache/$ver/go
 then
@@ -118,9 +155,7 @@ else
     mkdir -p $cache/$ver
     cd $cache/$ver
     start "Installing $ver"
-        curl -sO $url
-        tar zxf $file
-        rm -f $file
+        curl -s $url | tar zxf -
     finished
     cd - >/dev/null
 fi


### PR DESCRIPTION
This also does expansion of supported versions to the latest version in the branch (see tools/godep#318 and #100).

For .godir and Godeps file, they will be removed on 2016/02/01 (so plenty of time to switch).

The main difference wrt versions is that if you specific only the major version of go, the buildpack will give you the latest minor release of that go version. You can still set a specific minor version though (although not a major). This is more similar to the way most other buildpacks work.
