### PR TITLE
Only use env_dir if provided.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,6 +105,7 @@ GO_LINKER_VALUE=${SOURCE_VERSION}
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
 if [ ! -z "$env_dir" ]
 then
+    mkdir -p "$env_dir"
     env_dir=$(cd "$env_dir/" && pwd)
     ln -sfn $build /app/code
   for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GO_LINKER_SYMBOL GO_LINKER_VALUE GO15VENDOREXPERIMENT GOVERSION

--- a/bin/compile
+++ b/bin/compile
@@ -61,10 +61,10 @@ report_ver() {
   esac
 }
 
-mkdir -p "$1" "$2" "$3"
+mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
-env_dir=$(cd "$3/" && pwd)
+env_dir=$3
 buildpack=$(cd "$(dirname $0)/.." && pwd)
 arch=$(uname -m|tr A-Z a-z)
 if test $arch = x86_64

--- a/bin/compile
+++ b/bin/compile
@@ -103,8 +103,9 @@ finished() {
 GO_LINKER_VALUE=${SOURCE_VERSION}
 
 # allow apps to specify cgo flags and set up /app symlink so things like CGO_CFLAGS=-I/app/... work
-if [ -d "$env_dir" ]
+if [ ! -z "$env_dir" ]
 then
+    env_dir=$(cd "$env_dir/" && pwd)
     ln -sfn $build /app/code
   for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GO_LINKER_SYMBOL GO_LINKER_VALUE GO15VENDOREXPERIMENT GOVERSION
     do


### PR DESCRIPTION
Otherwise, we'll error out trying to create it. It seems to be optional, judging by the ruby buildpack. So we can just skip creating it, and let the existence check later fail.

/cc @fabiokung @freeformz 
