### PR TITLE
(WIP) GO15VENDOREXPERIMENT without godeps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -284,8 +284,6 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
-        pkgs=$(<$build/Godeps/Godeps.json jq -r 'if .Packages then .Packages | join(" ") else "." end')
-
         case $ver in
         go1.5*)
             if test "$GO15VENDOREXPERIMENT" = "1"

--- a/bin/compile
+++ b/bin/compile
@@ -284,7 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
-        $pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
 
         case $ver in
         go1.5*)

--- a/bin/compile
+++ b/bin/compile
@@ -284,6 +284,8 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
         
+        warn $name
+        warn $p
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
 
         case $ver in

--- a/bin/compile
+++ b/bin/compile
@@ -324,7 +324,7 @@ case $TOOL in
         if test "$VendorExperiment" = "true"
         then
             step "Running: go install -v -x ${FLAGS[@]} $pkgs"
-            GO15VENDOREXPERIMENT=1 go install -v -x "${FLAGS[@]} $pkgs"
+            go install -v -x "${FLAGS[@]}" $pkgs
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -284,10 +284,8 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
-        warn $(ls -1 $p)
-        warn $(ls -1 $build)
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
-
+        warn $pkgs
         case $ver in
         go1.5*)
             if test "$GO15VENDOREXPERIMENT" = "1"

--- a/bin/compile
+++ b/bin/compile
@@ -283,8 +283,10 @@ case $TOOL in
         p=$GOPATH/src/$name
         mkdir -p $p
         cp -R $build/* $p
-        
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr -d "$p" | tr '.go\n' ' ')
+
+        warn ls -1 $p
+        warn ls -1 $build        
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
 
         case $ver in
         go1.5*)

--- a/bin/compile
+++ b/bin/compile
@@ -284,8 +284,8 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
-        warn ls -1 $p
-        warn ls -1 $build        
+        warn $(ls -1 $p)
+        warn $(ls -1 $build)
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
 
         case $ver in

--- a/bin/compile
+++ b/bin/compile
@@ -319,8 +319,8 @@ case $TOOL in
         cd $p
         if test "$VendorExperiment" = "true"
         then
-            step "Running: go install -v ${FLAGS[@]} $pkgs"
-            go install -v "${FLAGS[@]}" $pkgs
+            step "Running: go install -v ${FLAGS[@]}"
+            go install -v "${FLAGS[@]}"
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -320,7 +320,7 @@ case $TOOL in
         if test "$VendorExperiment" = "true"
         then
             step "Running: go install -v ${FLAGS[@]} ."
-            go install -v "${FLAGS[@]} ."
+            go install -v "${FLAGS[@]} ./..."
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -277,7 +277,7 @@ case $TOOL in
         warn "GO15VENDOREXPERIMENT, without another build tool, is unsupported."
         warn ""
         GOBIN=$build/bin export GOBIN
-        GOPATH=$build/.heroku/go export GOPATH
+        GOPATH=$build/vendor:$build/.heroku/go export GOPATH
         PATH=$GOROOT/bin:$PATH
 
         p=$GOPATH/src/$name

--- a/bin/compile
+++ b/bin/compile
@@ -284,9 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
         
-        warn $name
-        warn $p
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '.go\n' ' ')
 
         case $ver in
         go1.5*)
@@ -324,7 +322,7 @@ case $TOOL in
         if test "$VendorExperiment" = "true"
         then
             step "Running: go install -v -x ${FLAGS[@]} $pkgs"
-            go install -v -x "${FLAGS[@]}" $pkgs
+            go install -v "${FLAGS[@]} $pkgs"
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -284,7 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
         
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr -d $build | tr '.go\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr -d "$p" | tr '.go\n' ' ')
 
         case $ver in
         go1.5*)

--- a/bin/compile
+++ b/bin/compile
@@ -280,9 +280,9 @@ case $TOOL in
         GOPATH=$build/.heroku/go export GOPATH
         PATH=$GOROOT/bin:$PATH
 
-        p=$GOPATH/src/$name
-        mkdir -p $p
-        cp -R $build/* $p
+        #p=$GOPATH/src/$name
+        #mkdir -p $p
+        #cp -R $build/* $p
 
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
 

--- a/bin/compile
+++ b/bin/compile
@@ -284,7 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
         
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '.go\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" . | tr -d './' | tr '.go\n' ' ')
 
         case $ver in
         go1.5*)

--- a/bin/compile
+++ b/bin/compile
@@ -284,7 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
         
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" . | tr -d './' | tr '.go\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr -d $build | tr '.go\n' ' ')
 
         case $ver in
         go1.5*)

--- a/bin/compile
+++ b/bin/compile
@@ -285,7 +285,7 @@ case $TOOL in
         cp -R $build/* $p
 
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
-        warn $pkgs
+
         case $ver in
         go1.5*)
             if test "$GO15VENDOREXPERIMENT" = "1"
@@ -322,7 +322,7 @@ case $TOOL in
         if test "$VendorExperiment" = "true"
         then
             step "Running: go install -v -x ${FLAGS[@]} $pkgs"
-            go install -v "${FLAGS[@]} $pkgs"
+            go install "${FLAGS[@]}" -v $pkgs
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -322,7 +322,7 @@ case $TOOL in
         if test "$VendorExperiment" = "true"
         then
             step "Running: go install -v ${FLAGS[@]} $pkgs"
-            go install -v "${FLAGS[@]} $pkgs"
+            GO15VENDOREXPERIMENT=1 go install -v "${FLAGS[@]} $pkgs"
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -277,7 +277,7 @@ case $TOOL in
         warn "GO15VENDOREXPERIMENT, without another build tool, is unsupported."
         warn ""
         GOBIN=$build/bin export GOBIN
-        GOPATH=$build/vendor:$build/.heroku/go export GOPATH
+        GOPATH=$build/.heroku/go export GOPATH
         PATH=$GOROOT/bin:$PATH
 
         p=$GOPATH/src/$name
@@ -319,8 +319,8 @@ case $TOOL in
         cd $p
         if test "$VendorExperiment" = "true"
         then
-            step "Running: go install -v ${FLAGS[@]}"
-            go install -v "${FLAGS[@]}"
+            step "Running: go install -v ${FLAGS[@]} ."
+            go install -v "${FLAGS[@]} ."
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -280,12 +280,11 @@ case $TOOL in
         GOPATH=$build/.heroku/go export GOPATH
         PATH=$GOROOT/bin:$PATH
 
-        #p=$GOPATH/src/$name
-        #mkdir -p $p
-        #cp -R $build/* $p
+        p=$GOPATH/src/$name
+        mkdir -p $p
+        cp -R $build/* $p
         
-        cd $build
-        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
+        pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $p | tr '\n' ' ')
 
         case $ver in
         go1.5*)
@@ -322,8 +321,8 @@ case $TOOL in
         cd $p
         if test "$VendorExperiment" = "true"
         then
-            step "Running: go install -v ${FLAGS[@]} $pkgs"
-            GO15VENDOREXPERIMENT=1 go install -v "${FLAGS[@]} $pkgs"
+            step "Running: go install -v -x ${FLAGS[@]} $pkgs"
+            GO15VENDOREXPERIMENT=1 go install -v -x "${FLAGS[@]} $pkgs"
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/compile
+++ b/bin/compile
@@ -128,6 +128,10 @@ elif (test -d "$build/src" && test -n "$(find "$build/src" -type f -name '*.go' 
 then
     ver=${GOVERSION:-$DEFAULT_GO_VERSION}
     TOOL="gb"
+elif (test "$GO15VENDOREXPERIMENT" = "1" && test -d "$build/vendor")
+then
+  ver=${GOVERSION:-$DEFAULT_GO_VERSION}
+  TOOL="govendor"
 else
     warn "Godep or GB are required. For instructions:"
     warn "https://devcenter.heroku.com/articles/go-support"
@@ -186,7 +190,7 @@ case $TOOL in
         GOBIN=$build/bin export GOBIN
         GOPATH=$build/.heroku/go export GOPATH
         PATH=$GOROOT/bin:$PATH
-        
+
         p=$GOPATH/src/$name
         mkdir -p $p
         cp -R $build/* $p
@@ -267,6 +271,65 @@ case $TOOL in
         step "Post Compile Cleanup"
         for f in bin/*-heroku; do mv "$f" "${f/-heroku}"; done
         rm -rf pkg
+    ;;
+  govendor)
+        warn ""
+        warn "GO15VENDOREXPERIMENT, without another build tool, is unsupported."
+        warn ""
+        GOBIN=$build/bin export GOBIN
+        GOPATH=$build/.heroku/go export GOPATH
+        PATH=$GOROOT/bin:$PATH
+
+        p=$GOPATH/src/$name
+        mkdir -p $p
+        cp -R $build/* $p
+
+        pkgs=$(<$build/Godeps/Godeps.json jq -r 'if .Packages then .Packages | join(" ") else "." end')
+
+        case $ver in
+        go1.5*)
+            if test "$GO15VENDOREXPERIMENT" = "1"
+            then
+                warn ""
+                warn "\$GO15VENDOREXPERIMENT=1. This is an experiment. Things may not work as expected."
+                warn "See https://devcenter.heroku.com/articles/go-support#go-1-5-vendor-experiment for more info."
+                warn ""
+                if test ! -d "$build/vendor"
+                then
+                    warn ""
+                    warn "vendor/ directory does not exist."
+                    warn ""
+                    exit 1
+                fi
+                VendorExperiment="true"
+            fi
+        ;;
+        go1.6*)
+            if test "$GO15VENDOREXPERIMENT" = "0"
+            then
+                VendorExperiment="false"
+            else
+                VendorExperiment="true"
+            fi
+        ;;
+        *)
+            VendorExperiment="false"
+        ;;
+        esac
+
+        unset GIT_DIR # unset git dir or it will mess with goinstall
+        cd $p
+        if test "$VendorExperiment" = "true"
+        then
+            step "Running: go install -v ${FLAGS[@]} $pkgs"
+            go install -v "${FLAGS[@]}" $pkgs
+        else
+            warn ""
+            warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."
+            warn "Set GO15VENDOREXPERIMENT=1, and try again."
+            warn ""
+            exit 1
+        fi
     ;;
 esac
 

--- a/bin/compile
+++ b/bin/compile
@@ -283,7 +283,8 @@ case $TOOL in
         #p=$GOPATH/src/$name
         #mkdir -p $p
         #cp -R $build/* $p
-
+        
+        cd $build
         pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
 
         case $ver in

--- a/bin/compile
+++ b/bin/compile
@@ -284,6 +284,8 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
+        $pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" . | tr '\n' ' ')
+
         case $ver in
         go1.5*)
             if test "$GO15VENDOREXPERIMENT" = "1"

--- a/bin/compile
+++ b/bin/compile
@@ -284,7 +284,7 @@ case $TOOL in
         mkdir -p $p
         cp -R $build/* $p
 
-        $pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" . | tr '\n' ' ')
+        $pkgs=$(grep -l -R --exclude-dir=vendor --exclude-dir=.git "func main" $build | tr '\n' ' ')
 
         case $ver in
         go1.5*)
@@ -321,8 +321,8 @@ case $TOOL in
         cd $p
         if test "$VendorExperiment" = "true"
         then
-            step "Running: go install -v ${FLAGS[@]} ."
-            go install -v "${FLAGS[@]} ./..."
+            step "Running: go install -v ${FLAGS[@]} $pkgs"
+            go install -v "${FLAGS[@]} $pkgs"
         else
             warn ""
             warn "BUILD FAILED. GO15VENDOREXPERIMENT is disabled."

--- a/bin/detect
+++ b/bin/detect
@@ -6,13 +6,10 @@ build=$(cd "$1/" && pwd)
 
 if test -f "$build/Godeps/Godeps.json" ||
    (test -d "$build/src" && test -n "$(find "$build/src" -type f -name '*.go' | sed 1q)") || # gb info will detect any dir with a src/ dir in it as good :-()
-   ((test "$GO15VENDOREXPERIMENT" = "1") && test -d "$build/vendor")) || # detect vendor expiriment (go1.7 which will drop the need for $GO15VENDOREXPERIMENT)
+   (test -d "$build/vendor") || # detect vendor folder. can't check value of $GO15VENDOREXPERIMENT (go1.7 which will drop the need for $GO15VENDOREXPERIMENT)
    test -f "$build/Godeps" -o -f "$build/.godir"  # deprecated remove on 2016/02/01
 then
   echo Go
 else
-  echo $GO15VENDOREXPERIMENT
-  echo ("$GO15VENDOREXPERIMENT" = "1")
-  echo (test -d "$build/vendor")
   exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -6,10 +6,13 @@ build=$(cd "$1/" && pwd)
 
 if test -f "$build/Godeps/Godeps.json" ||
    (test -d "$build/src" && test -n "$(find "$build/src" -type f -name '*.go' | sed 1q)") || # gb info will detect any dir with a src/ dir in it as good :-()
-   (test "$GO15VENDOREXPERIMENT" = "1" && test -d "$build/vendor") || # detect vendor expiriment (go1.7 which will drop the need for $GO15VENDOREXPERIMENT)
+   ((test "$GO15VENDOREXPERIMENT" = "1") && test -d "$build/vendor")) || # detect vendor expiriment (go1.7 which will drop the need for $GO15VENDOREXPERIMENT)
    test -f "$build/Godeps" -o -f "$build/.godir"  # deprecated remove on 2016/02/01
 then
   echo Go
 else
+  echo $GO15VENDOREXPERIMENT
+  echo ("$GO15VENDOREXPERIMENT" = "1")
+  echo (test -d "$build/vendor")
   exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -6,6 +6,7 @@ build=$(cd "$1/" && pwd)
 
 if test -f "$build/Godeps/Godeps.json" ||
    (test -d "$build/src" && test -n "$(find "$build/src" -type f -name '*.go' | sed 1q)") || # gb info will detect any dir with a src/ dir in it as good :-()
+   (test "$GO15VENDOREXPERIMENT" = "1" && test -d "$build/vendor") || # detect vendor expiriment (go1.7 which will drop the need for $GO15VENDOREXPERIMENT)
    test -f "$build/Godeps" -o -f "$build/.godir"  # deprecated remove on 2016/02/01
 then
   echo Go

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -21,6 +21,17 @@ test
 EOF
 }
 
+
+_createGoVendorProject()
+{
+_createSimpleGoMain
+
+  mkdir -p ${BUILD_DIR}/vendor
+  cat > ${BUILD_DIR}/vendor/.gitkeep <<EOF
+test
+EOF
+}
+
 _createGodepsProject()
 {
 _createSimpleGoMain
@@ -59,6 +70,19 @@ testCompileGodirApp() {
   assertCapturedSuccess
   assertCaptured "should install default Go version" "-----> Installing go1.4.1... done"
   assertCaptured "should recommend godep" "Try github.com/kr/godep for faster deploys."
+  assertCaptured "should install Virtualenv" "Installing Virtualenv... done"
+  assertCaptured "should install Mercurial" "Installing Mercurial... done"
+  assertCaptured "should install Bazaar" "Installing Bazaar... done"
+  assertCaptured "should run go get" "-----> Running: go get -tags heroku ./..."
+}
+
+testCompileGoVendorApp() {
+  _createGoVendorProject
+
+  compile
+
+  assertCapturedSuccess
+  assertCaptured "should install default Go version" "-----> Installing go1.6... done"
   assertCaptured "should install Virtualenv" "Installing Virtualenv... done"
   assertCaptured "should install Mercurial" "Installing Mercurial... done"
   assertCaptured "should install Bazaar" "Installing Bazaar... done"

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -3,16 +3,16 @@
 
 testDetect_NotFound()
 {
-  detect  
-  
+  detect
+
   assertNoAppDetected
 }
 
 testDetect_Go()
 {
   touch ${BUILD_DIR}/main.go
-  
-  detect  
+
+  detect
 
   assertAppDetected "Go"
 }


### PR DESCRIPTION
After growing frustrated with `godeps`, I decided to embrace the official
vendoring solution provided by `GO15VENDOREXPERIMENT`, which is now on
by default, and will come standard in 1.7 (won't be able to disable it).

This patch is my attempt to support `GO15VENDOREXPERIMENT` in a
dependency manager agnostic way.

Personally, I am using [`glide`](https://glide.sh) to manage my `vendor/` directory,
but realized that at this juncture this buildpack doesn't need to
support any particular tool to support a more generic vendored
dependency approach, since any front-end tool is irrelevant and not used
by go when the app is compiled.

This buildpack will now detect if `$GO15VENDOREXPERIMENT` is set to
`"1"`, and that a `vendor/` directory exists. If these are found, a
simple `go install` is run (using the appropriate flags). This should
work for those without any vendored dependencies, provided they have a
placeholder file in `vendor/` to ensure the directory can be pushed to
git.

This is my first attempt at hacking on a buildpack, so any feedback is
welcome and appreciated.

A couple of loose ends that may need attention:
- I don't test the version of go that is being used, to ensure it's 1.5 or greater.
- The text I `warn` users about in the build step should probably link
  to articles in your devcenter, recommend that you use `godeps`, etc.
