### PR TITLE
Retry curl operations for up to 30 seconds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,7 @@ set -eo pipefail
 TOOL=""
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
+CURL="curl --retry 15 --retry-delay 2" # retry for up to 30 seconds
 
 handleDefaultPkgSpec() {
     if [ "$pkgs" = "default" ];
@@ -206,7 +207,7 @@ else
     mkdir -p $cache/$ver
     cd $cache/$ver
     start "Installing $ver"
-        curl -s $url | tar zxf -
+        $CURL -s $url | tar zxf -
     finished
     cd - >/dev/null
 fi
@@ -321,7 +322,7 @@ case $TOOL in
             mkdir -p "$cp"
             cd $cp
             start "Installing GB v$gbver"
-            curl -s "https://codeload.github.com/constabulary/gb/tar.gz/v$gbver" | tar zxf -
+            $CURL -s "https://codeload.github.com/constabulary/gb/tar.gz/v$gbver" | tar zxf -
             mv gb-$gbver gb
             go install ./...
             finished


### PR DESCRIPTION
We have seen occasional `tar` and EOF errors from the go buildpack v31 when `curl` fails to fetch the go tarball. This adds `--retry` flags to make that more robust.

Refs deis/slugbuilder#50.
