### PR TITLE
export PATH so it's more accessbile during runtime

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -341,5 +341,5 @@ esac
 rm -rf $build/.heroku
 
 mkdir -p $build/.profile.d
-echo 'PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
+echo 'export PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
 cp $buildpack/vendor/concurrency.sh $build/.profile.d/


### PR DESCRIPTION
This mini change makes the`PATH` env var accessible to any sub-processes during runtime in the dyno.
