### PR TITLE
Massage the pkg spec found in Godep.json for vendor

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -345,8 +345,9 @@ case $TOOL in
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd $p
-        step "Running: go install -v ${FLAGS[@]} $pkgs"
-        go install -v "${FLAGS[@]}" $pkgs
+        massagePkgSpecForVendor
+        step "Running: go install -v ${FLAGS[@]} ${pkgs}"
+        go install -v "${FLAGS[@]}" ${pkgs}
     ;;
     gb)
         warn ""

--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,18 @@ handleDefaultPkgSpec() {
     fi
 }
 
+massagePkgSpecForVendor() {
+    local t=""
+    for p in $(echo $pkgs); do
+      if [ "${p:0:1}" = "." ] && [ ! -d "$name/vendor/$p" ]; then
+        t+="${p} "
+      else
+        t+="${name}/vendor/${p} "
+      fi
+    done
+    pkgs="${t}"
+}
+
 # Go releases have moved to a new URL scheme
 # starting with Go version 1.2.2. Return the old
 # location for known old versions and the new
@@ -311,11 +323,12 @@ case $TOOL in
         cd $p
         if test "$VendorExperiment" = "true"
         then
-            step "Running: go install -v ${FLAGS[@]} $pkgs"
-            go install -v "${FLAGS[@]}" $pkgs
+            massagePkgSpecForVendor
+            step "Running: go install -v ${FLAGS[@]} ${pkgs}"
+            go install -v "${FLAGS[@]}" ${pkgs}
         else
-            step "Running: godep go install ${FLAGS[@]} $pkgs"
-            godep go install "${FLAGS[@]}" $pkgs
+            step "Running: godep go install ${FLAGS[@]} ${pkgs}"
+            godep go install "${FLAGS[@]}" ${pkgs}
         fi
     ;;
     govendor)


### PR DESCRIPTION
Godep can save other packages other than what's local.

This is usually used to vendor one or more additional main packages like
github.com/mattes/migrate. With the old school godep workspace this just
worked because the workspace was added to the GOPATH by `godep go
install`. But with the vendor experiment we need to prefix those paths
with the `<the package>/vendor` for them to be `go install`able.

So this patch checks to see if the directory for the packages that
aren't `.*` packages exists in `<repo>/vendor` and if they do, alters
the package name to `<repo package name>/vendor/<package>`.
