### PR TITLE
No longer require a `Procfile` for Godeps and Govendor

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -508,6 +508,11 @@ case ${TOOL} in
     ;;
 esac
 
+if ! test -e $build/Procfile && test -n "${name}"
+then
+  echo -e "web: $(basename $name)" >> $build/Procfile
+fi
+
 rm -rf $build/.heroku
 
 mkdir -p $build/.profile.d

--- a/test/run
+++ b/test/run
@@ -388,6 +388,14 @@ testCompileGodepBasic() {
   assertFileDoesNotExist ".profile.d/concurrency.sh"
 }
 
+testCompileGodepCreateProcfile() {
+  compile "godep-basic"
+  assertCaptured "Installing go"
+  assertCapturedSuccess
+  assertCompiledBinaryExists
+  assertFile "web: fixture" "Procfile"
+}
+
 testDetectGovendorBasic() {
   detect "govendor-basic"
   assertCaptured "Go"
@@ -402,6 +410,14 @@ testCompileGovendorBasic() {
   assertCaptured "github.com/heroku/fixture"
   assertCapturedSuccess
   assertCompiledBinaryExists
+}
+
+testCompileGovendorCreateProcfile() {
+  compile "govendor-basic"
+  assertCaptured "Installing go"
+  assertCapturedSuccess
+  assertCompiledBinaryExists
+  assertFile "web: fixture" "Procfile"
 }
 
 testDetectGodepOldWorkspace() {


### PR DESCRIPTION
- This makes the go buildpack run the generated main package binary name to start the web worker if no  procfile is present and no start command is specified
