### PR TITLE
Allow common go patterns

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -6,7 +6,9 @@ build=$(cd "$1/" && pwd)
 
 if test -f "$build/Godeps/Godeps.json" || # godeps
    test -f "$build/vendor/vendor.json" || # govendor
-   (test -d "$build/src" && test -n "$(find "$build/src" -mindepth 2 -type f -name '*.go' | sed 1q)") # gb
+   (test -d "$build/src" && test -n "$(find "$build/src" -mindepth 2 -type f -name '*.go' | sed 1q)") || # gb
+   test -f "$build/main.go" ||
+   test -f "$build/cmd/main.go"
 then
   echo Go
 else


### PR DESCRIPTION
Feels silly to insist that a project is go only when its using a
dependency tool. This PR would allow projects using common go file
structures to be recognised as go.

```
main.go
cmd/main.go
```
