### PR TITLE
Add .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/fixtures/glide-with-deps/vendor/github.com/heroku/slog"]
+	path = test/fixtures/glide-with-deps/vendor/github.com/heroku/slog
+	url = https://github.com/heroku/slog.git


### PR DESCRIPTION
This should have been added in d0ff462, and not having it committed means `git clone --recursive` fails on this repository:

```
$ git clone --recursive --quiet https://github.com/heroku/heroku-buildpack-go.git
No submodule mapping found in .gitmodules for path 'test/fixtures/glide-with-deps/vendor/github.com/heroku/slog'
```
