### PR TITLE
1.7rc5 as default for 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+go1.7rc5 is the default for go1.7
+
+#v44
+
 go1.7rc3 is the default for go1.7
 
 #v43 (2016-07-19)

--- a/bin/compile
+++ b/bin/compile
@@ -122,7 +122,7 @@ urlFor() {
 expandVer() {
   case $1 in
     go1.7)
-      echo "go1.7rc3"
+      echo "go1.7rc5"
       ;;
     go1.6)
       echo "go1.6.3"


### PR DESCRIPTION
This change make 1.7rc5 the default for builds requesting 1.7
