### PR TITLE
$GOVERSION and $GO_INSTALL_PACKAGE_SPEC take precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 go1.7rc5 is the default for go1.7
+GOVERSION & GO_INSTALL_PACKAGE_SPEC take priority over config files for godep/govendor. This is to help people deploying the same repo to multiple apps, allowing them to compile only specific packages and choose different go versions.
 
 #v44
 

--- a/bin/compile
+++ b/bin/compile
@@ -215,6 +215,19 @@ warnGoVersionOverride() {
   fi
 }
 
+warnPackageSpecOverride() {
+  if test ! -z "${GO_INSTALL_PACKAGE_SPEC}"
+  then
+    warn "Using \$GO_INSTALL_PACKAGE_SPEC override."
+    warn "     \$GO_INSTALL_PACKAGE_SPEC = ${GO_INSTALL_PACKAGE_SPEC}"
+    warn ""
+    warn "If this isn't what you want please run:'"
+    warn "  heroku config:unset GO_INSTALL_PACKAGE_SPEC -a <app>"
+    warn ""
+  fi
+}
+
+
 # -----------------------------------------
 # load environment variables
 # allow apps to specify cgo flags. The literal text '${build_dir}' is substituted for the build directory
@@ -370,6 +383,7 @@ case ${TOOL} in
         cp -R $build/* $p
 
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${godepsJSON} jq -r 'if .Packages then .Packages | join(" ") else "default" end')}
+        warnPackageSpecOverride
         handleDefaultPkgSpec
 
         case $ver in
@@ -454,6 +468,7 @@ case ${TOOL} in
         cp -R ${build}/* ${p}
 
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${vendorJSON} jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')}
+        warnPackageSpecOverride
         handleDefaultPkgSpec
 
         unset GIT_DIR # unset git dir or it will mess with goinstall

--- a/bin/compile
+++ b/bin/compile
@@ -245,7 +245,7 @@ then
         exit 1
     fi
     name=$(<${godepsJSON} jq -r .ImportPath)
-    ver=${GOVERSION!-$(<${godepsJSON} jq -r .GoVersion)}
+    ver=${GOVERSION:-$(<${godepsJSON} jq -r .GoVersion)}
     warnGoVersionOverride
 elif test -f "${vendorJSON}"
 then

--- a/bin/compile
+++ b/bin/compile
@@ -208,6 +208,10 @@ warnGoVersionOverride() {
   then
     warn "Using \$GOVERSION override."
     warn "     \$GOVERSION = ${GOVERSION}"
+    warn ""
+    warn "If this isn't what you want please run:'"
+    warn "  heroku config:unset GOVERSION -a <app>"
+    warn ""
   fi
 }
 

--- a/bin/compile
+++ b/bin/compile
@@ -203,6 +203,14 @@ setGoVersionFromEnvironment() {
   ver=${GOVERSION:-$DefaultGoVersion}
 }
 
+warnGoVersionOverride() {
+  if test ! -z "${GOVERSION}"
+  then
+    warn "Using \$GOVERSION override."
+    warn "     \$GOVERSION = ${GOVERSION}"
+  fi
+}
+
 # -----------------------------------------
 # load environment variables
 # allow apps to specify cgo flags. The literal text '${build_dir}' is substituted for the build directory
@@ -233,7 +241,8 @@ then
         exit 1
     fi
     name=$(<${godepsJSON} jq -r .ImportPath)
-    ver=$(<${godepsJSON} jq -r .GoVersion)
+    ver=${GOVERSION!-$(<${godepsJSON} jq -r .GoVersion)}
+    warnGoVersionOverride
 elif test -f "${vendorJSON}"
 then
     TOOL="govendor"
@@ -255,10 +264,11 @@ then
         exit 1
 
     fi
-    ver=$(<${vendorJSON} jq -r .heroku.goVersion)
+    ver=${GOVERSION:-$(<${vendorJSON} jq -r .heroku.goVersion)}
+    warnGoVersionOverride
     if [ "${ver}" =  "null" -o -z "${ver}" ]
     then
-      ver=${GOVERSION:-$DefaultGoVersion}
+      ver=${DefaultGoVersion}
       warn "The 'heroku.goVersion' field is not specified in 'vendor/vendor.json'."
       warn ""
       warn "Defaulting to ${ver}"

--- a/bin/compile
+++ b/bin/compile
@@ -355,7 +355,7 @@ case ${TOOL} in
         mkdir -p $p
         cp -R $build/* $p
 
-        pkgs=$(<$build/Godeps/Godeps.json jq -r 'if .Packages then .Packages | join(" ") else "default" end')
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<$build/Godeps/Godeps.json jq -r 'if .Packages then .Packages | join(" ") else "default" end')}
         handleDefaultPkgSpec
 
         case $ver in
@@ -439,7 +439,7 @@ case ${TOOL} in
         mkdir -p ${p}
         cp -R ${build}/* ${p}
 
-        pkgs=$(<$build/vendor/vendor.json jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<$build/vendor/vendor.json jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')}
         handleDefaultPkgSpec
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
@@ -465,7 +465,7 @@ case ${TOOL} in
         mkdir -p "${p}"
         cp -R "${build}/"* "${p}"
 
-        pkgs=${GO_INSTALL_PACKAGE_SPEC-"default"}
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-"default"}
         handleDefaultPkgSpec
 
         unset GIT_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -355,7 +355,7 @@ case ${TOOL} in
         mkdir -p $p
         cp -R $build/* $p
 
-        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<$build/Godeps/Godeps.json jq -r 'if .Packages then .Packages | join(" ") else "default" end')}
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${godepsJSON} jq -r 'if .Packages then .Packages | join(" ") else "default" end')}
         handleDefaultPkgSpec
 
         case $ver in
@@ -439,7 +439,7 @@ case ${TOOL} in
         mkdir -p ${p}
         cp -R ${build}/* ${p}
 
-        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<$build/vendor/vendor.json jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')}
+        pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${vendorJSON} jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')}
         handleDefaultPkgSpec
 
         unset GIT_DIR # unset git dir or it will mess with goinstall

--- a/test/fixtures/godep-cmd/Godeps/Godeps.json
+++ b/test/fixtures/godep-cmd/Godeps/Godeps.json
@@ -1,0 +1,6 @@
+{
+    "GoVersion": "go1.6",
+    "ImportPath": "github.com/heroku/fixture",
+    "Packages":["./..."],
+    "Deps": []
+}

--- a/test/fixtures/godep-cmd/cmd/fixture/main.go
+++ b/test/fixtures/godep-cmd/cmd/fixture/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("fixture")
+}

--- a/test/fixtures/godep-cmd/cmd/other/main.go
+++ b/test/fixtures/godep-cmd/cmd/other/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("other")
+}

--- a/test/fixtures/govendor-cmd/cmd/fixture/main.go
+++ b/test/fixtures/govendor-cmd/cmd/fixture/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("fixture")
+}

--- a/test/fixtures/govendor-cmd/cmd/other/main.go
+++ b/test/fixtures/govendor-cmd/cmd/other/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("other")
+}

--- a/test/fixtures/govendor-cmd/vendor/vendor.json
+++ b/test/fixtures/govendor-cmd/vendor/vendor.json
@@ -1,0 +1,10 @@
+{
+	"rootPath": "github.com/heroku/fixture",
+	"comment": "",
+	"ignore": "test",
+	"heroku": {
+		"install":["./..."]
+	},
+	"package": [
+    ]
+}

--- a/test/fixtures/govendor-go15/main.go
+++ b/test/fixtures/govendor-go15/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/test/fixtures/govendor-go15/vendor/vendor.json
+++ b/test/fixtures/govendor-go15/vendor/vendor.json
@@ -1,0 +1,9 @@
+{
+	"heroku": {
+		"goVersion": "go1.5"
+	},
+	"rootPath": "github.com/heroku/fixture",
+	"comment": "",
+	"ignore": "test",
+	"package": []
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testCompileGodepBasicGo14WithGOVERSIONOverride() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo 'go1.6' > "${env_dir}/GOVERSION"
+  compile "godep-basic-go14" ${cache} ${env_dir}
+  assertCaptured "Installing go1.6"
+  assertCapturedSuccess
+  assertCompiledBinaryExists
+  assertFileDoesNotExist ".profile.d/concurrency.sh"
+}
+
+testCompileGovendorGo14WithGOVERSIONOverride() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo 'go1.6' > "${env_dir}/GOVERSION"
+  compile "govendor-go15" ${cache} ${env_dir}
+  assertCaptured "Installing go1.6"
+  assertCapturedSuccess
+  assertCompiledBinaryExists
+}
+
 testDetectGlideMassageVendor() {
   detect "glide-massage-vendor"
   assertCaptured "Go"

--- a/test/run
+++ b/test/run
@@ -14,6 +14,8 @@ testCompileGovendorCmdsOverride() {
   local env_dir=$(mktmpdir)
   echo './cmd/fixture' > "${env_dir}/GO_INSTALL_PACKAGE_SPEC"
   compile "govendor-cmd" ${cache} ${env_dir}
+  assertCapturedSuccess
+  assertCaptured "Using \$GO_INSTALL_PACKAGE_SPEC override."
   assertCompiledBinaryExists "fixture"
   assertCompiledBinaryOutputs "fixture" "fixture"
   assertFileDoesNotExist "bin/other"
@@ -43,6 +45,7 @@ testCompileGodepBasicGo14WithGOVERSIONOverride() {
   echo 'go1.6' > "${env_dir}/GOVERSION"
   compile "godep-basic-go14" ${cache} ${env_dir}
   assertCaptured "Installing go1.6"
+  assertCaptured "Using \$GOVERSION override."
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertFileDoesNotExist ".profile.d/concurrency.sh"
@@ -54,6 +57,7 @@ testCompileGovendorGo14WithGOVERSIONOverride() {
   echo 'go1.6' > "${env_dir}/GOVERSION"
   compile "govendor-go15" ${cache} ${env_dir}
   assertCaptured "Installing go1.6"
+  assertCaptured "Using \$GOVERSION override."
   assertCapturedSuccess
   assertCompiledBinaryExists
 }

--- a/test/run
+++ b/test/run
@@ -1,6 +1,42 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testCompileGovendorCmds() {
+  compile "govendor-cmd"
+  assertCapturedSuccess
+  assertCompiledBinaryExists "fixture"
+  assertCompiledBinaryOutputs "fixture" "fixture"
+  assertCompiledBinaryExists "other"
+  assertCompiledBinaryOutputs "other" "other"
+}
+testCompileGovendorCmdsOverride() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo './cmd/fixture' > "${env_dir}/GO_INSTALL_PACKAGE_SPEC"
+  compile "govendor-cmd" ${cache} ${env_dir}
+  assertCompiledBinaryExists "fixture"
+  assertCompiledBinaryOutputs "fixture" "fixture"
+  assertFileDoesNotExist "bin/other"
+}
+
+testCompileGodepCmds() {
+  compile "godep-cmd"
+  assertCapturedSuccess
+  assertCompiledBinaryExists "fixture"
+  assertCompiledBinaryOutputs "fixture" "fixture"
+  assertCompiledBinaryExists "other"
+  assertCompiledBinaryOutputs "other" "other"
+}
+testCompileGodepCmdsOverride() {
+  local cache=$(mktmpdir)
+  local env_dir=$(mktmpdir)
+  echo './cmd/fixture' > "${env_dir}/GO_INSTALL_PACKAGE_SPEC"
+  compile "godep-cmd" ${cache} ${env_dir}
+  assertCompiledBinaryExists "fixture"
+  assertCompiledBinaryOutputs "fixture" "fixture"
+  assertFileDoesNotExist "bin/other"
+}
+
 testCompileGodepBasicGo14WithGOVERSIONOverride() {
   local cache=$(mktmpdir)
   local env_dir=$(mktmpdir)

--- a/test/shunit2
+++ b/test/shunit2
@@ -978,7 +978,6 @@ _shunit_extractTestFunctions()
 #------------------------------------------------------------------------------
 # main
 #
-
 # determine the operating mode
 if [ $# -eq 0 ]; then
   __shunit_script=${__SHUNIT_PARENT}


### PR DESCRIPTION
This allows users who are using a "monorepo" to push code and only compile sub parts of the repo  / specify different go versions.

/cc @dpiddy @cyx 
