### PR TITLE
$HOME/.heroku/go instead of $HOME/.go

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -612,10 +612,10 @@ echo 'PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
 
 if test "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true"
 then
-    start "Copying go tool chain to \$GOROOT=\$HOME/.go"
-        mkdir -p "${build}/.go"
-        cp -a "${GOROOT}/"* "${build}/.go"
-        echo 'export GOROOT=$HOME/.go' > "${build}/.profile.d/goroot.sh"
+    start "Copying go tool chain to \$GOROOT=\$HOME/.heroku/go"
+        mkdir -p "${build}/.heroku/go"
+        cp -a "${GOROOT}/"* "${build}/.heroku/go"
+        echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
         echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
     finished
     step "Copying ${TOOL} binary"

--- a/test/run
+++ b/test/run
@@ -181,7 +181,7 @@ testCompileGlideBasicWithTools() {
   assertCaptured "github.com/heroku/fixture"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFileExists ".go/bin/go"
+  assertFileExists ".heroku/go/bin/go"
 }
 testCompileGlideBasicInGOPATH() {
   local cache=$(mktmpdir)
@@ -455,7 +455,7 @@ testCompileGBBasicWithTools() {
   assertCaptured "Copying gb binary"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFileExists ".go/bin/go"
+  assertFileExists ".heroku/go/bin/go"
 }
 
 testDetectGodepLDSymbolValue() {
@@ -525,7 +525,7 @@ testCompileGodepBasicWithTools() {
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertFileDoesNotExist ".profile.d/concurrency.sh"
-  assertFileExists ".go/bin/go"
+  assertFileExists ".heroku/go/bin/go"
 }
 testCompileGodepBasicInGOPATH() {
   local cache=$(mktmpdir)
@@ -581,7 +581,7 @@ testCompileGovendorBasicWithTools() {
   assertCaptured "Copying govendor binary"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFileExists ".go/bin/go"
+  assertFileExists ".heroku/go/bin/go"
 }
 testCompileGovendorBasicInGOPATH() {
   local cache=$(mktmpdir)


### PR DESCRIPTION
This is more in line with other buildpacks (nodejs,php & python, but not jdk/ruby)
