### PR TITLE
Use S3 Bucket and verify files

### DIFF
--- a/.bkignore
+++ b/.bkignore
@@ -1,0 +1,1 @@
+file-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+file-cache/**

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,15 @@ test: test-cedar-14
 
 test-cedar-14:
 	@echo "Running tests in docker (cedar-14)..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=cedar-14" heroku/cedar:14 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; test/run;'
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it -e "STACK=cedar-14" heroku/cedar:14 bash -c 'mkdir -p /buildpack_test; tar --exclude=file-cache --exclude=.git -cf - -C /buildpack . | tar -x -C /buildpack_test; cd /buildpack_test/; test/run;'
 	@echo ""
 
 shell:
 	@echo "Opening cedar-14 shell..."
-	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/cedar:14 bash -c 'cp -r /buildpack /buildpack_test; cd /buildpack_test/; bash'
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/cedar:14 bash -c 'mkdir -p /buildpack_test; tar --exclude=file-cache --exclude=.git -cf - -C /buildpack . | tar -x -C /buildpack_test; cd /buildpack_test/; bash'
+	@echo ""
+
+quick:
+	@echo "Opening cedar-14 shell..."
+	@docker run -v $(shell pwd):/buildpack:ro --rm -it heroku/cedar:14 bash -c 'mkdir -p /buildpack_test; tar --exclude=file-cache --exclude=.git -cf - -C /buildpack . | tar -x -C /buildpack_test; cd /buildpack_test/; test/quick; bash'
 	@echo ""

--- a/bin/compile
+++ b/bin/compile
@@ -7,248 +7,258 @@ mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
 env_dir="${3}"
+
 buildpack=$(cd "$(dirname $0)/.." && pwd)
-arch=$(uname -m|tr A-Z a-z)
-if test $arch = x86_64
-then arch=amd64
-fi
-plat=$(uname|tr A-Z a-z)-$arch
-PATH=$buildpack/$plat/bin:$PATH
+source "${buildpack}/lib/common.sh"
+ensureInPath "jq-linux64" "${cache}/.jq/bin"
 
-steptxt="----->"
-YELLOW='\033[1;33m'
-RED='\033[1;31m'
-NC='\033[0m' # No Color
-CURL="curl -s -L --retry 15 --retry-delay 2" # retry for up to 30 seconds
-
-DefaultGoVersion="go1.7.4"
-GlideVersion="v0.12.2"
-GovendorVersion="1.0.8"
-GBVersion="0.4.3"
-PkgErrorsVersion="0.7.1"
-MercurialVersion="3.9"
+DefaultGoVersion="$(<${DataJSON} jq -r '.Go.DefaultVersion')"
+GlideVersion="$(<${DataJSON} jq -r '.Glide.DefaultVersion')"
+GovendorVersion="$(<${DataJSON} jq -r '.Govendor.DefaultVersion')"
+GBVersion="$(<${DataJSON} jq -r '.GB.DefaultVersion')"
+PkgErrorsVersion="$(<${DataJSON} jq -r '.PkgErrors.DefaultVersion')"
+MercurialVersion="$(<${DataJSON} jq -r '.HG.DefaultVersion')"
 # BazaarVersion="2.7.0"
-TOOL=""
-# Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile
-GO_LINKER_VALUE=${SOURCE_VERSION}
 
-# For older version of Go we need to keep concurrency.sh
+# For specified versions of Go we need to keep concurrency.sh
 needConcurrency() {
-  case $1 in
-    go1.7*|go1.6*)
-      return 1
-      ;;
-    *)
-      return 0
-      ;;
-  esac
+    <"${DataJSON}" jq -e '.Go.NeedsConcurrency | indices(["'${1}'"]) | length | if . == 0 then false else true end' &> /dev/null
 }
 
 handleDefaultPkgSpec() {
-  if [ "${pkgs}" = "default" ];
-  then
-    warn "Installing package '.' (default)"
-    warn ""
-    case "${TOOL}" in
-      govendor)
-        warn "To install a different package spec set 'heroku.install' in 'vendor/vendor.json'"
+    if [ "${pkgs}" = "default" ]; then
+        warn "Installing package '.' (default)"
         warn ""
-        warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
-      ;;
-      glide)
-        warn "To install a different package spec for the next build run:"
+        case "${TOOL}" in
+            govendor)
+                warn "To install a different package spec set 'heroku.install' in 'vendor/vendor.json'"
+                warn ""
+                warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
+            ;;
+            glide)
+                warn "To install a different package spec for the next build run:"
+                warn ""
+                warn "'heroku config:set GO_INSTALL_PACKAGE_SPEC=\"<pkg spec>\"'"
+                warn ""
+                warn "For more details see: https://devcenter.heroku.com/articles/go-dependencies-via-glide"
+            ;;
+        esac
         warn ""
-        warn "'heroku config:set GO_INSTALL_PACKAGE_SPEC=\"<pkg spec>\"'"
-        warn ""
-        warn "For more details see: https://devcenter.heroku.com/articles/go-dependencies-via-glide"
-      ;;
-    esac
-    warn ""
-    pkgs="."
-  fi
+        pkgs="."
+    fi
 }
 
 massagePkgSpecForVendor() {
     local t=""
     for pkg in $(echo $pkgs); do
-      if [ "${pkg:0:1}" = "." ] || [ ! -d "./vendor/$pkg" ]; then
-        t+="${pkg} "
-      else
-        t+="${name}/vendor/${pkg} "
-      fi
+        if [ "${pkg:0:1}" = "." ] || [ ! -d "./vendor/$pkg" ]; then
+            t+="${pkg} "
+        else
+            t+="${name}/vendor/${pkg} "
+        fi
     done
     pkgs="${t}"
 }
 
-# Go releases have moved to a new URL scheme
-# starting with Go version 1.2.2. Return the old
-# location for known old versions and the new
-# location otherwise.
+# TODO: go1 is missing from storage.googleapis.com and we haven't manually compiled it yet
 urlFor() {
     local ver=$1
     case $ver in
-    go1.0*|go1.1beta*|go1.1rc*|go1.1|go1.1.*|go1.2beta*|go1.2rc*|go1.2|go1.2.1)
-        local file=${GOFILE:-$ver.linux-amd64.tar.gz}
-        echo https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/$file
+        devel*)
+            local sha=$(echo ${ver} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
+            echo https://github.com/golang/go/archive/$sha.tar.gz
         ;;
-    devel*)
-        local sha=$(echo $ver | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
-        echo https://github.com/golang/go/archive/$sha.tar.gz
-    ;;
-    *)
-        local file=${GOFILE:-$ver.linux-amd64.tar.gz}
-        echo https://storage.googleapis.com/golang/$file
+        *)
+            local file="${ver}.linux-amd64.tar.gz"
+            echo ${BucketURL}/${file}
         ;;
     esac
 }
 
-# Expand to supported versions of Go, (e.g. expand "go1.5" to latest release go1.5.2)
-# All specific or other versions, take as is.
+# Expand to supported versions of Go, see data.json for supported expansions.
+# All others are returned as is.
 expandVer() {
-  case $1 in
-    go1.7)
-      echo "go1.7.4"
-      ;;
-    go1.6)
-      echo "go1.6.4"
-      ;;
-    go1.5)
-      echo "go1.5.4"
-      ;;
-    go1.4)
-      echo "go1.4.3"
-      ;;
-    *)
-      echo "$1"
-      ;;
-  esac
+    echo $(<${DataJSON} jq -r 'if .Go.VersionExpansion."'${1}'" then .Go.VersionExpansion."'${1}'" else "'${1}'" end')
 }
 
 # Report deprecated versions to user
 # Use after expandVer
 reportVer() {
-  case $1 in
-    go1.7.4|go1.6.4)
-      # Noop
-    ;;
-    devel*)
-      warn ""
-      warn "You are using a development build of Go."
-      warn "This is provided for users requiring an unreleased Go version"
-      warn "but is otherwise unsupported."
-      warn ""
-      warn "Build tests are NOT RUN!!"
-      warn ""
-    ;;
-    *)
-      warn ""
-      warn "Deprecated or unsupported version of go ($1)"
-      warn "See https://devcenter.heroku.com/articles/go-support#go-versions for supported version information."
-      warn ""
-    ;;
-  esac
+    if <"${DataJSON}" jq -e '.Go.Supported | indices(["'${1}'"]) | length | if . > 0 then true else false end' &> /dev/null; then
+        return
+    fi
+    case $1 in
+        devel*)
+            warn ""
+            warn "You are using a development build of Go."
+            warn "This is provided for users requiring an unreleased Go version"
+            warn "but is otherwise unsupported."
+            warn ""
+            warn "Build tests are NOT RUN!!"
+            warn ""
+        ;;
+        *)
+            warn ""
+            warn "Deprecated or unsupported version of go ($1)"
+            warn "See https://devcenter.heroku.com/articles/go-support#go-versions for supported version information."
+            warn ""
+        ;;
+    esac
 }
 
 ensureHG() {
-    local hgv="${1}"
-    local thgp=$(mktemp -d)
-    local hgp="${cache}/hg/${hgv}"
-    #local hgb="${hgp}/hg"
-    if test -d "${hgp}"
-    then
-        step "Using hg v${hgv}"
+    local hgVersion="${1}"
+    local tmp=$(mktemp -d)
+    local hgPath="${cache}/hg/${hgVersion}"
+    if [ -x "${hgPath}/bin/hg" ]; then
+        step "Using hg v${hgVersion}"
     else
         rm -rf "${cache}/hg"
-        mkdir -p "${hgp}"
-        start "Installing hg ${hgv}"
-          $CURL "https://www.mercurial-scm.org/release/mercurial-${hgv}.tar.gz" | tar -zxf - --strip-components=1 -C ${thgp}
-          pushd "${thgp}" &> /dev/null
-          python setup.py install --force --home=${hgp} &> /dev/null
-          popd &> /dev/null
+        mkdir -p "${hgPath}"
+        start "Installing hg ${hgVersion}"
+            ensureFile "mercurial-${hgVersion}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
+            pushd "${tmp}" &> /dev/null
+                python setup.py install --force --home="${hgPath}" &> /dev/null
+            popd &> /dev/null
         finished
     fi
 
-    PATH="${hgp}/bin:${PATH}"
-}
-
-ensureBZR() {
-    local bzrv="${1}"
-    local bzrvs=$(echo ${bzrv} | cut -d . -f 1,2)
-    local tbzrp=$(mktemp -d)
-    local bzrp="${cache}/bzr/${bzrv}"
-    if test -d "${bzrp}"
-    then
-        step "Using bzr v${bzrv}"
-    else
-        rm -rf "${cache}/bzr"
-        mkdir -p "${bzrp}"
-        start "Installing bzr ${bzrv}"
-          $CURL "https://launchpad.net/bzr/${bzrvs}/${bzrv}/+download/bzr-${bzrv}.tar.gz" | tar -zxf - --strip-components=1 -C ${tbzrp}
-          pushd "${tbzrp}" &> /dev/null
-          python setup.py install --force --home=${bzrp} &> /dev/null
-          popd &> /dev/null
-        finished
-    fi
-
-    PATH="${bzrp}/bin:${PATH}"
-    export PYTHONPATH="${bzrp}/lib/python:${PYTHONPATH}"
+    addToPATH "${hgPath}/bin"
 }
 
 ensureGlide() {
-    local gv=${1}
-    local gvPath="${cache}/glide/${gv}/bin"
-    local gvBin="${gvPath}/glide"
+    local glideVersion="${1}"
+    local gPath="${cache}/glide/${glideVersion}/bin"
+    local gBin="${gPath}/glide"
+    local gFile="glide-${glideVersion}-linux-amd64.tar.gz"
+    local targetFile="${gPath}/${gFile}"
 
-    if test -d "${gvPath}"
-    then
-        step "Using glide ${gv}"
+    if [ -x "${gBin}" ]; then
+        step "Using glide ${glideVersion}"
     else
-      rm -rf "${cache}/glide"
-      mkdir -p "${gvPath}"
-      start "Installing glide ${gv}"
-        $CURL "https://github.com/Masterminds/glide/releases/download/${gv}/glide-${gv}-linux-amd64.tar.gz" | tar -zxf - --strip-components=1 -C ${gvPath}
-        chmod a+x ${gvBin}
-      finished
+        rm -rf "${cache}/glide"
+        start "Installing glide ${glideVersion}"
+            ensureInPath "${gFile}" "${gPath}" "tar -C ${gPath} --strip-components=1 -zxf"
+            chmod a+x "${gBin}"
+            rm -f "${targetFile}"
+        finished
+    fi
+}
+
+ensureGB() {
+    local gbVersion="${1}"
+    GOPATH="${cache}/gb/${gbVersion}"
+    PATH="${GOPATH}/bin:${PATH}"
+    local pkgErrsFile="errors-${PkgErrorsVersion}.tar.gz"
+    local pkgErrorsPath="${GOPATH}/src/github.com/pkg/errors"
+    local gbFile="gb-${gbVersion}.tar.gz"
+    local gbPath="${GOPATH}/src/github.com/constabulary/gb"
+    if [ -d "${GOPATH}" ]; then
+        step "Using GB ${gbVersion}"
+    else
+        rm -rf "${cache}/gb/*"
+        ensureFile "${pkgErrsFile}" "${pkgErrorsPath}" "tar -C ${pkgErrorsPath} --strip-components=1 -zxf"
+        rm -f "${pkgErrorsPath}/${pkgErrsFile}"
+
+        ensureFile "${gbFile}" "${gbPath}" "tar -C ${gbPath} --strip-components=1 -zxf"
+        rm -f "${gbPath}/${gbFile}"
+
+        start "Installing GB v${GBVersion}"
+            pushd "${gbPath}" &> /dev/null
+                go install ./...
+            popd &> /dev/null
+        finished
+    fi
+}
+
+ensureGo() {
+    local goVersion="${1}"
+    local goPath="${cache}/${goVersion}/go"
+    local goFile=""
+    local txt="Installing ${goVersion}"
+    if [ -d "${goPath}" ]; then
+        step "Using ${goVersion}"
+    else
+        rm -rf ${cache}/* #For a go version change, we delete everything
+        case "${goVersion}" in
+            devel*)
+                local bGoVersion="$(expandVer ${DefaultGoVersion})"
+                goFile="${bGoVersion}.linux-amd64.tar.gz"
+                goPath="${cache}/${bGoVersion}/go"
+                txt="Installing bootstrap ${bGoVersion}"
+            ;;
+            go1)
+                goFile="go.go1.linux-amd64.tar.gz"
+            ;;
+            *)
+                goFile="${goVersion}.linux-amd64.tar.gz"
+            ;;
+        esac
+
+        step "${txt}"
+        ensureFile "${goFile}" "${goPath}" "tar -C ${goPath} --strip-components=1 -zxf"
+        rm -f "${goPath}/${goFile}"
+
+        case "${goVersion}" in
+            devel*)
+                pushd "${cache}/${bGoVersion}" &> /dev/null
+                    mv go bgo
+                    local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
+                    local url="https://github.com/golang/go/archive/$sha.tar.gz"
+                    start "Downloading development Go version ${bGoVersion}"
+                        ${CURL} ${url} | tar zxf -
+                        mv go-${sha}* go
+                    finished
+                    step "Compiling development Go version ${goVersion}"
+                    pushd go/src &> /dev/null
+                        echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
+                        GOROOT_BOOTSTRAP=$(pushd ${cache}/${goVersion}/bgo > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
+                    popd &> /dev/null
+                    go/bin/go version
+                    rm -rf bgo
+                popd &> /dev/null
+            ;;
+            *)
+            ;;
+        esac
     fi
 
-    PATH="${gvPath}:${PATH}"
+    export GOROOT="${goPath}"
+    PATH="${goPath}/bin:${PATH}"
 }
 
 setGoVersionFromEnvironment() {
-  if test -z "${GOVERSION}"
-  then
-    warn ""
-    warn "'GOVERSION' isn't set, defaulting to '${DefaultGoVersion}'"
-    warn ""
-    warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
-    warn "for future builds"
-    warn ""
-  fi
-  ver=${GOVERSION:-$DefaultGoVersion}
+    if [ -z "${GOVERSION}" ]; then
+        warn ""
+        warn "'GOVERSION' isn't set, defaulting to '${DefaultGoVersion}'"
+        warn ""
+        warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
+        warn "for future builds"
+        warn ""
+    fi
+    ver=${GOVERSION:-$DefaultGoVersion}
 }
 
 warnGoVersionOverride() {
-  if test ! -z "${GOVERSION}"
-  then
-    warn "Using \$GOVERSION override."
-    warn "     \$GOVERSION = ${GOVERSION}"
-    warn ""
-    warn "If this isn't what you want please run:'"
-    warn "  heroku config:unset GOVERSION -a <app>"
-    warn ""
-  fi
+    if [ ! -z "${GOVERSION}" ]; then
+        warn "Using \$GOVERSION override."
+        warn "     \$GOVERSION = ${GOVERSION}"
+        warn ""
+        warn "If this isn't what you want please run:'"
+        warn "  heroku config:unset GOVERSION -a <app>"
+        warn ""
+    fi
 }
 
 warnPackageSpecOverride() {
-  if test ! -z "${GO_INSTALL_PACKAGE_SPEC}"
-  then
-    warn "Using \$GO_INSTALL_PACKAGE_SPEC override."
-    warn "     \$GO_INSTALL_PACKAGE_SPEC = ${GO_INSTALL_PACKAGE_SPEC}"
-    warn ""
-    warn "If this isn't what you want please run:'"
-    warn "  heroku config:unset GO_INSTALL_PACKAGE_SPEC -a <app>"
-    warn ""
-  fi
+    if [ ! -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
+        warn "Using \$GO_INSTALL_PACKAGE_SPEC override."
+        warn "     \$GO_INSTALL_PACKAGE_SPEC = ${GO_INSTALL_PACKAGE_SPEC}"
+        warn ""
+        warn "If this isn't what you want please run:'"
+        warn "  heroku config:unset GO_INSTALL_PACKAGE_SPEC -a <app>"
+        warn ""
+    fi
 }
 
 # Sets up GOPATH (and posibly other GO* env vars) and returns the location of
@@ -257,8 +267,7 @@ setupGOPATH() {
     local name="${1}"
     local t="$(mktemp -d)"
 
-    if test "${GO_SETUP_GOPATH_IN_IMAGE}" = "true"
-    then
+    if [ "${GO_SETUP_GOPATH_IN_IMAGE}" = "true" ]; then
         mv -t ${t} ${build}/*
         GOPATH="${build}"
     else
@@ -275,15 +284,12 @@ setupGOPATH() {
     echo "src=${src}"
 }
 
-source "${buildpack}/lib/common.sh"
 loadEnvDir "${env_dir}"
 determineTool
 
 ver=$(expandVer $ver)
-url=${GOURL:-$(urlFor $ver)}
 
-if test -e $build/bin && ! test -d $build/bin
-then
+if [ -e "${build}/bin" -a ! -d "${build}/bin" ]; then
     err ""
     err "File bin exists and is not a directory."
     err ""
@@ -292,53 +298,19 @@ fi
 
 reportVer $ver
 
-if test -d "${cache}/${ver}/go"
-then
-    step "Using ${ver}"
-else
-    rm -rf ${cache}/* # be sure not to build up cruft
-    mkdir -p "${cache}/${ver}"
-    odir="$(pwd)"
-    cd "${cache}/${ver}"
-    start "Installing ${ver}"
-        ${CURL} ${url} | tar zxf -
-    finished
-    case ${ver} in  # Rename 'go-<full sha>' (we have the short sha) to 'go'
-    devel*)
-        bver=$(expandVer ${DefaultGoVersion})
-        burl=$(urlFor ${bver})
-        start "Installing bootstrap Go version ${bver}"
-            ${CURL} ${burl} | tar zxf -
-        finished
-        mv go bgo
-        mv go-$(echo ${ver} | cut -d - -f 2)* go
-        step "Compiling development Go version $ver..."
-            cd go/src
-            echo "devel +$(echo ${ver} | cut -d - -f 2) $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
-            GOROOT_BOOTSTRAP=$(pushd ${cache}/${ver}/bgo > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
-            cd - >/dev/null
-            go/bin/go version
-        finished
-        rm -rf bgo
-    ;;
-    esac
-    cd $odir
-fi
+ensureGo "${ver}"
 
 mkdir -p $build/bin
-export GOROOT="${cache}/${ver}/go"
-PATH="${PATH}:${GOROOT}/bin"
 
 # If $GO_LINKER_SYMBOL and GO_LINKER_VALUE are set, tell the linker to DTRT
 FLAGS=(-tags heroku)
-if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]
-then
-    case $ver in
-    go1.5*|go1.6*|go1.7*)
-        xval="${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}"
+if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]; then
+    case "${ver}" in
+        go1.0*|go1.1*|go1.2*|go1.3*|go1.4*)
+            xval="${GO_LINKER_SYMBOL} ${GO_LINKER_VALUE}"
         ;;
-    *)
-        xval="${GO_LINKER_SYMBOL} ${GO_LINKER_VALUE}"
+        *)
+            xval="${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}"
         ;;
     esac
     FLAGS=(${FLAGS[@]} -ldflags "-X ${xval}")
@@ -347,7 +319,7 @@ fi
 export GOPATH
 
 # GB installation
-case ${TOOL} in
+case "${TOOL}" in
     godep)
         eval "$(setupGOPATH ${name})"
         godepsJSON="${src}/Godeps/Godeps.json"
@@ -356,78 +328,46 @@ case ${TOOL} in
         warnPackageSpecOverride
         handleDefaultPkgSpec
 
-        case $ver in
-        go1.5*)
-            if test "$GO15VENDOREXPERIMENT" = "1"
-            then
-                warn ""
-                warn "\$GO15VENDOREXPERIMENT=1. This is an experiment. Things may not work as expected."
-                warn "See https://devcenter.heroku.com/articles/go-support#go-1-5-vendor-experiment for more info."
-                warn ""
-                if test ! -d "$build/vendor"
-                then
-                    err ""
-                    err "vendor/ directory does not exist."
-                    err ""
-                    exit 1
-                fi
-                VendorExperiment="true"
+        UseGodepCommand="false" # Default to not wrapping go install with godep (vendor)
+
+        if <"${DataJSON}" jq -e '.Go.SupportsVendorExperiment | indices(["'${ver}'"]) | length | if . == 0 then false else true end' &> /dev/null; then
+            case "${ver}" in
+                go1.5*) #go1.5* defaults to disable vendor
+                    if [ -z "${GO15VENDOREXPERIMENT}" -o "${GO15VENDOREXPERIMENT}" = "0" ]; then
+                        UseGodepCommand="true"
+                    fi
+                ;;
+                go1.6*) #go1.6* defaults to enable vendor
+                    if [ "${GO15VENDOREXPERIMENT}" = "0" ]; then
+                        UseGodepCommand="true"
+                    fi
+                ;;
+            esac
+        else
+            if [ -n "${GO15VENDOREXPERIMENT}" ]; then
+                err ""
+                err "GO15VENDOREXPERIMENT is set, but is not supported by ${ver}"
+                err "run `heroku config:unset GO15VENDOREXPERIMENT`"
+                err "before pushing again."
+                err ""
+                exit 1
             fi
-        ;;
-        go1.6*)
-            if test "$GO15VENDOREXPERIMENT" = "0" || test -d "${src}/Godeps/_workspace/src"
-            then
-                VendorExperiment="false"
-            else
-                VendorExperiment="true"
-            fi
-        ;;
-        go1.7*)
-          if test -n "$GO15VENDOREXPERIMENT"
-          then
-            err ""
-            err "GO15VENDOREXPERIMENT is set, but is not supported by go1.7"
-            err "run `heroku config:unset GO15VENDOREXPERIMENT`"
-            err "before pushing again."
-            err ""
-            exit 1
-          fi
-          VendorExperiment="true"
-        ;;
-        *)
-            VendorExperiment="false"
-        ;;
-        esac
+        fi
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
-        if test "$VendorExperiment" = "true"
-        then
+        if [ "${UseGodepCommand}" = "true" ]; then
+            step "Running: godep go install -v ${FLAGS[@]} ${pkgs}"
+            godep go install -v "${FLAGS[@]}" ${pkgs} 2>&1
+        else
             massagePkgSpecForVendor
             step "Running: go install -v ${FLAGS[@]} ${pkgs}"
             go install -v "${FLAGS[@]}" ${pkgs} 2>&1
-        else
-            step "Running: godep go install -v ${FLAGS[@]} ${pkgs}"
-            godep go install -v "${FLAGS[@]}" ${pkgs} 2>&1
         fi
     ;;
     govendor)
-        govendorPath="${cache}/govendor/${GovendorVersion}/bin"
-        govendorBin="${govendorPath}/govendor"
-        if test -d "${govendorBin}"
-        then
-          step "Using govendor v${GovendorVersion}"
-        else
-          rm -rf "${cache}/govendor"
-          mkdir -p "${govendorPath}"
-          start "Installing govendor v${GovendorVersion}"
-            $CURL "https://github.com/kardianos/govendor/releases/download/v${GovendorVersion}/govendor_linux_amd64" > "${govendorBin}"
-            chmod a+x "${govendorBin}"
-          finished
+        ensureInPath "govendor_linux_amd64" "${cache}/govendor/bin"
 
-        fi
-
-        PATH="${govendorPath}:$PATH"
         eval "$(setupGOPATH ${name})"
         vendorJSON="${src}/vendor/vendor.json"
 
@@ -438,8 +378,7 @@ case ${TOOL} in
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
 
-        if test "$(<${vendorJSON} jq -r '.heroku.sync')" != "false"
-        then
+        if [ "$(<${vendorJSON} jq -r '.heroku.sync')" != "false" ]; then
             step "Fetching any unsaved dependencies (govendor sync)"
             govendor sync
         fi
@@ -449,9 +388,8 @@ case ${TOOL} in
         go install -v "${FLAGS[@]}" ${pkgs} 2>&1
     ;;
     glide)
-        ensureGlide ${GlideVersion}
-        ensureHG ${MercurialVersion}
-        # ensureBZR ${BazaarVersion}
+        ensureGlide "${GlideVersion}"
+        ensureHG "${MercurialVersion}"
 
         # Do this before setupGOPATH as we need ${name} set first
         cd "${build}"
@@ -474,54 +412,33 @@ case ${TOOL} in
         go install -v "${FLAGS[@]}" ${pkgs} 2>&1
     ;;
     gb)
-        GOPATH="${cache}/gb/${GBVersion}"
-        PATH="${GOPATH}/bin:${PATH}"
-        cp="${GOPATH}/src/github.com/constabulary"
-        pp="${GOPATH}/src/github.com/pkg"
-        if test -d "${GOPATH}"
-        then
-            step "Using GB ${GBVersion}"
-        else
-            rm -rf "${cache}/gb/*" # cruft bad
-            mkdir -p "${pp}"
-            cd "${pp}"
-            $CURL "https://codeload.github.com/pkg/errors/tar.gz/v${PkgErrorsVersion}" | tar zxf -
-            mv "errors-${PkgErrorsVersion}" errors
-            mkdir -p "${cp}"
-            cd "${cp}"
-            start "Installing GB v${GBVersion}"
-            $CURL "https://codeload.github.com/constabulary/gb/tar.gz/v${GBVersion}" | tar zxf -
-            mv "gb-${GBVersion}" gb
-            go install ./...
-            finished
-        fi
+        ensureGB "${GBVersion}"
 
         cd $build
         step "Running: gb build ${FLAGS[@]}"
         gb build "${FLAGS[@]}" 2>&1
 
         step "Post Compile Cleanup"
-        for f in bin/*-heroku; do mv "$f" "${f/-heroku}"; done
+        for f in bin/*-heroku; do
+            mv "$f" "${f/-heroku}"
+        done
         rm -rf pkg
     ;;
 esac
 
-if test ! -z "${src}" -a "${src}" != "${build}" -a -e "${src}/Procfile"
-then
-  mv -t "${build}" "${src}/Procfile"
+if [ -n "${src}" -a "${src}" != "${build}" -a -e "${src}/Procfile" ]; then
+    mv -t "${build}" "${src}/Procfile"
 fi
 
-if ! test -e $build/Procfile && test -n "${name}"
-then
-  echo -e "web: $(basename $name)" >> $build/Procfile
+if [ ! -e $build/Procfile -a -n "${name}" ]; then
+    echo -e "web: $(basename $name)" >> $build/Procfile
 fi
 
 cd $build
 mkdir -p $build/.profile.d
 echo 'PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
 
-if test "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true"
-then
+if [ "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true" ]; then
     start "Copying go tool chain to \$GOROOT=\$HOME/.heroku/go"
         mkdir -p "${build}/.heroku/go"
         cp -a "${GOROOT}/"* "${build}/.heroku/go"
@@ -532,8 +449,7 @@ then
     cp $(which ${TOOL}) "${build}/bin"
 fi
 
-if test "${GO_SETUP_GOPATH_IN_IMAGE}" = "true"
-then
+if [ "${GO_SETUP_GOPATH_IN_IMAGE}" = "true" ]; then
     start "Cleaning up \$GOPATH/pkg"
         rm -rf $GOPATH/pkg
     finished
@@ -541,16 +457,14 @@ then
     echo 'cd $GOPATH/src/'${name} >> "${build}/.profile.d/zzgopath.sh" # because of this
 fi
 
-if needConcurrency ${ver};
-then
-  cp $buildpack/vendor/concurrency.sh $build/.profile.d/
+if needConcurrency ${ver}; then
+    cp $buildpack/vendor/concurrency.sh $build/.profile.d/
 fi
 
 t="${build}/.heroku/go"
 mkdir -p "${t}"
 t="${t}/.meta"
 echo "TOOL=${TOOL}" > "${t}"
-if test "${TOOL}" != "gb"
-then
+if [ "${TOOL}" != "gb" ]; then
     echo "NAME=${name}" >> "${t}"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -34,6 +34,7 @@ handleDefaultPkgSpec() {
                 warn "To install a different package spec set 'heroku.install' in 'vendor/vendor.json'"
                 warn ""
                 warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
+                warn ""
             ;;
             glide)
                 warn "To install a different package spec for the next build run:"
@@ -41,9 +42,9 @@ handleDefaultPkgSpec() {
                 warn "'heroku config:set GO_INSTALL_PACKAGE_SPEC=\"<pkg spec>\"'"
                 warn ""
                 warn "For more details see: https://devcenter.heroku.com/articles/go-dependencies-via-glide"
+                warn ""
             ;;
         esac
-        warn ""
         pkgs="."
     fi
 }
@@ -322,7 +323,6 @@ export GOPATH
 # GB installation
 case "${TOOL}" in
     godep)
-        ensureInPath "godep_linux_amd64" "${cache}/godep/bin"
         eval "$(setupGOPATH ${name})"
         godepsJSON="${src}/Godeps/Godeps.json"
 
@@ -340,10 +340,21 @@ case "${TOOL}" in
                 warn ""
             fi
         fi
+        # Warn that GO15VENDOREXPIERMENT is set, but the go version does not support it.
+        if <"${DataJSON}" jq -e '.Go.SupportsVendorExperiment | indices(["'${ver}'"]) | length | if . == 0 then true else false end' &> /dev/null; then
+            if [ -n "${GO15VENDOREXPERIMENT}" ]; then
+                warn ""
+                warn "GO15VENDOREXPERIMENT is set, but is not supported by ${ver}"
+                warn "run \`heroku config:unset GO15VENDOREXPERIMENT\` to unset."
+                warn ""
+            fi
+        fi
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
         if [ "${UseGodepCommand}" = "true" ]; then
+            ensureInPath "godep_linux_amd64" "${cache}/godep/bin"
+
             step "Running: godep go install -v ${FLAGS[@]} ${pkgs}"
             godep go install -v "${FLAGS[@]}" ${pkgs} 2>&1
         else

--- a/bin/compile
+++ b/bin/compile
@@ -333,28 +333,13 @@ case "${TOOL}" in
         handleDefaultPkgSpec
 
         UseGodepCommand="false" # Default to not wrapping go install with godep (vendor)
-
-        if <"${DataJSON}" jq -e '.Go.SupportsVendorExperiment | indices(["'${ver}'"]) | length | if . == 0 then false else true end' &> /dev/null; then
-            case "${ver}" in
-                go1.5*) #go1.5* defaults to disable vendor
-                    if [ -z "${GO15VENDOREXPERIMENT}" -o "${GO15VENDOREXPERIMENT}" = "0" ]; then
-                        UseGodepCommand="true"
-                    fi
-                ;;
-                go1.6*) #go1.6* defaults to enable vendor
-                    if [ "${GO15VENDOREXPERIMENT}" = "0" ]; then
-                        UseGodepCommand="true"
-                    fi
-                ;;
-            esac
-        else
-            if [ -n "${GO15VENDOREXPERIMENT}" ]; then
-                err ""
-                err "GO15VENDOREXPERIMENT is set, but is not supported by ${ver}"
-                err "run `heroku config:unset GO15VENDOREXPERIMENT`"
-                err "before pushing again."
-                err ""
-                exit 1
+        if [ -d "${src}/Godeps/_workspace/src" ]; then
+            UseGodepCommand="true"
+            if [ -d "${src}/vendor" ]; then
+                warn ""
+                warn "Godeps/_workspace/src and vendor/ exist"
+                warn "code may not compile. Please convert all deps to vendor/"
+                warn ""
             fi
         fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -321,6 +321,7 @@ export GOPATH
 # GB installation
 case "${TOOL}" in
     godep)
+        ensureInPath "godep_linux_amd64" "${cache}/godep/bin"
         eval "$(setupGOPATH ${name})"
         godepsJSON="${src}/Godeps/Godeps.json"
 

--- a/bin/compile
+++ b/bin/compile
@@ -201,22 +201,25 @@ ensureGo() {
 
         case "${goVersion}" in
             devel*)
-                pushd "${cache}/${bGoVersion}" &> /dev/null
-                    mv go bgo
-                    local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
-                    local url="https://github.com/golang/go/archive/$sha.tar.gz"
-                    start "Downloading development Go version ${bGoVersion}"
-                        ${CURL} ${url} | tar zxf -
-                        mv go-${sha}* go
-                    finished
-                    step "Compiling development Go version ${goVersion}"
-                    pushd go/src &> /dev/null
-                        echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
-                        GOROOT_BOOTSTRAP=$(pushd ${cache}/${goVersion}/bgo > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
+                pushd "${cache}" &> /dev/null
+                    mkdir -p "${goVersion}"
+                    pushd "${goVersion}" &> /dev/null
+                        local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
+                        local url="https://github.com/golang/go/archive/$sha.tar.gz"
+                        start "Downloading development Go version ${goVersion}"
+                            ${CURL} ${url} | tar zxf -
+                            mv go-${sha}* go
+                        finished
+                        step "Compiling development Go version ${goVersion}"
+                        pushd go/src &> /dev/null
+                            echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
+                            GOROOT_BOOTSTRAP=$(pushd ${cache}/${bGoVersion}/go > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
+                        popd &> /dev/null
+                        go/bin/go version
+                        rm -rf "${goPath}"
                     popd &> /dev/null
-                    go/bin/go version
-                    rm -rf bgo
                 popd &> /dev/null
+                goPath="${cache}/${goVersion}/go"
             ;;
             *)
             ;;
@@ -296,11 +299,11 @@ if [ -e "${build}/bin" -a ! -d "${build}/bin" ]; then
     exit 1
 fi
 
-reportVer $ver
+reportVer "${ver}"
 
 ensureGo "${ver}"
 
-mkdir -p $build/bin
+mkdir -p "${build}/bin"
 
 # If $GO_LINKER_SYMBOL and GO_LINKER_VALUE are set, tell the linker to DTRT
 FLAGS=(-tags heroku)

--- a/bin/compile
+++ b/bin/compile
@@ -443,8 +443,10 @@ if [ "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true" ]; then
         echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
         echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
     finished
-    step "Copying ${TOOL} binary"
-    cp $(which ${TOOL}) "${build}/bin"
+    if which ${TOOL} &> /dev/null; then
+      step "Copying ${TOOL} binary"
+      cp $(which ${TOOL}) "${build}/bin"
+    fi
 fi
 
 if [ "${GO_SETUP_GOPATH_IN_IMAGE}" = "true" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -115,12 +115,11 @@ ensureHG() {
     else
         rm -rf "${cache}/hg"
         mkdir -p "${hgPath}"
-        start "Installing hg ${hgVersion}"
-            ensureFile "mercurial-${hgVersion}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
-            pushd "${tmp}" &> /dev/null
-                python setup.py install --force --home="${hgPath}" &> /dev/null
-            popd &> /dev/null
-        finished
+        step "Installing hg ${hgVersion}"
+        ensureFile "mercurial-${hgVersion}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
+        pushd "${tmp}" &> /dev/null
+            python setup.py install --force --home="${hgPath}" &> /dev/null
+        popd &> /dev/null
     fi
 
     addToPATH "${hgPath}/bin"
@@ -137,11 +136,10 @@ ensureGlide() {
         step "Using glide ${glideVersion}"
     else
         rm -rf "${cache}/glide"
-        start "Installing glide ${glideVersion}"
-            ensureInPath "${gFile}" "${gPath}" "tar -C ${gPath} --strip-components=1 -zxf"
-            chmod a+x "${gBin}"
-            rm -f "${targetFile}"
-        finished
+        step "Installing glide ${glideVersion}"
+        ensureInPath "${gFile}" "${gPath}" "tar -C ${gPath} --strip-components=1 -zxf"
+        chmod a+x "${gBin}"
+        rm -f "${targetFile}"
     fi
 }
 

--- a/bin/sync-files.sh
+++ b/bin/sync-files.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -e
+
+BUCKET="s3://heroku-golang-prod/"
+
+if [ -z "$ACCESS_KEY" -o -z "$SECRET_KEY" ]; then
+  echo "ACCESS_KEY and SECRET_KEY must be set"
+  exit 1
+fi
+
+S3CMD="s3cmd --access_key=${ACCESS_KEY} --secret_key=${SECRET_KEY}"
+
+tools=(jq curl shasum s3cmd)
+for tool in ${tools[@]}; do
+  if ! which -s ${tool}; then
+    continue
+  fi
+  tools=( "${tools[@]/${tool}}" )
+done
+
+if [ ${#tools} -ne 0 ]; then
+  echo "The following tools are missing from \$PATH and are required to run this script"
+  echo -e "\t${tools[@]}"
+  echo
+  exit 1
+fi
+
+# assumes we are in bin, find the directory above that
+cwd="$(cd $(dirname $0); cd ..; pwd)"
+jf="${cwd}/files.json"
+
+td="${cwd}/file-cache"
+mkdir -p "${td}"
+cd "${td}"
+
+#echo "Syncing contents of ${BUCKET} to $(pwd)."
+#${S3CMD} sync --check-md5 ${BUCKET} ./
+
+FILES=($(ls))
+
+echo "Ensuring that we have the right versions of all files specified in files.json"
+for f in $(< "${jf}" jq -r 'keys[]'); do
+  if [ ! -e "${f}" ]; then
+    u="$(< "${jf}" jq -r '."'${f}'".URL')"
+    echo "Downloading: ${u}"
+    curl -J -O -L --retry 15 --retry-delay 2 $u
+  fi
+
+  s="$(< "${jf}" jq -r '."'${f}'".SHA')"
+  if [ ${#s} -eq 40 ]; then
+    sf="$(shasum "${f}" | cut -d \  -f 1)"
+  else
+    sf="$(shasum -a 256 "${f}" | cut -d \  -f 1)"
+  fi
+  if [ "${sf}" != "${s}" ]; then
+    echo "SHA of file '${f}' differs from known SHA"
+    echo "know SHA: ${s}"
+    echo "file SHA: ${sf}"
+    echo
+    echo "Please erase the file and run again"
+    echo "If this persists, please validate the known SHA"
+    exit 1
+  fi
+
+  echo "VALID: ${f} SHA ${s}"
+  echo
+
+  FILES=(${FILES[@]/${f}})
+done
+
+if [ ${#FILES[@]} -gt 0 ]; then
+  echo "EXTRA FILES IN ${td}."
+  echo "Please delete these files and then run again"
+  for f in ${FILES[@]}; do
+    echo -e "\t${cwd}/$f"
+  done
+  exit 1
+fi
+
+echo "All files verified, syncing to s3"
+echo
+${S3CMD} sync -P --no-guess-mime-type --check-md5 --delete-removed --preserve --delete-after ./ ${BUCKET}

--- a/bin/test
+++ b/bin/test
@@ -8,8 +8,8 @@ build="$(cd ${1}/ && pwd)"
 env_dir="$(cd ${2}/ && pwd)"
 #artifact_dir="$(cd ${3} && pwd)"
 testpack=$(cd "$(dirname $0)/.." && pwd)
-
 source "${testpack}/lib/common.sh"
+
 # loadEnvDir "${env_dir}"
 # For now, load all of env_dir
 if [ ! -z "${env_dir}" ]

--- a/data.json
+++ b/data.json
@@ -1,0 +1,44 @@
+{
+  "Go": {
+    "Supported": ["go1.6.4", "go1.7.4"],
+    "DefaultVersion": "go1.7.4",
+    "VersionExpansion": {
+      "go1.8": "go1.8beta1",
+      "go1.7": "go1.7.4",
+      "go1.6": "go1.6.4",
+      "go1.5": "go1.5.4",
+      "go1.4": "go1.4.3",
+      "go1.3": "go1.3.3",
+      "go1.2": "go1.2.2",
+      "go1.1": "go1.1.2",
+      "go1": "go1.0.3"
+    },
+    "NeedsConcurrency": [
+      "go1", "go1.0.1", "go1.0.2", "go1.0.3",
+      "go1.1", "go1.1.1", "go1.1.2",
+      "go1.2", "go1.2.1", "go1.2.2",
+      "go1.3", "go1.3.1", "go1.3.2", "go1.3.3",
+      "go1.4", "go1.4.1", "go1.4.2", "go1.4.3",
+      "go1.5", "go1.5.1", "go1.5.2", "go1.5.3", "go1.5.4"
+      ],
+    "SupportsVendorExperiment": [
+      "go1.5", "go1.5.1", "go1.5.2", "go1.5.3", "go1.5.4",
+      "go1.6", "go1.6.1", "go1.6.2", "go1.6.3", "go1.6.4"
+    ]
+  },
+  "Glide": {
+    "DefaultVersion": "v0.12.3"
+  },
+  "Govendor": {
+    "DefaultVersion": "1.0.8"
+  },
+  "GB": {
+    "DefaultVersion": "0.4.3"
+  },
+  "PkgErrors": {
+    "DefaultVersion": "0.8.0"
+  },
+  "HG": {
+    "DefaultVersion": "3.9"
+  }
+}

--- a/data.json
+++ b/data.json
@@ -3,7 +3,7 @@
     "Supported": ["go1.6.4", "go1.7.4"],
     "DefaultVersion": "go1.7.4",
     "VersionExpansion": {
-      "go1.8": "go1.8beta1",
+      "go1.8": "go1.8beta2",
       "go1.7": "go1.7.4",
       "go1.6": "go1.6.4",
       "go1.5": "go1.5.4",

--- a/files.json
+++ b/files.json
@@ -1,0 +1,160 @@
+{
+    "go1.8beta1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.8beta1.linux-amd64.tar.gz",
+        "SHA": "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d"
+    },
+    "go1.7.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz",
+        "SHA": "47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b"
+    },
+    "go1.7.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz",
+        "SHA": "508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e"
+    },
+    "go1.7.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
+        "SHA": "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
+    },
+    "go1.7.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz",
+        "SHA": "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
+    },
+    "go1.6.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.6.4.linux-amd64.tar.gz",
+        "SHA": "b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf"
+    },
+    "go1.6.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz",
+        "SHA": "cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb"
+    },
+    "go1.6.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz",
+        "SHA": "e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a"
+    },
+    "go1.6.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz",
+        "SHA": "6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988"
+    },
+    "go1.6.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz",
+        "SHA": "5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
+    },
+    "go1.5.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.5.4.linux-amd64.tar.gz",
+        "SHA": "a3358721210787dc1e06f5ea1460ae0564f22a0fbd91be9dcd947fb1d19b9560"
+    },
+    "go1.5.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz",
+        "SHA": "43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53"
+    },
+    "go1.5.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz",
+        "SHA": "cae87ed095e8d94a81871281d35da7829bd1234e"
+    },
+    "go1.5.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz",
+        "SHA": "46eecd290d8803887dec718c691cc243f2175fe0"
+    },
+    "go1.5.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz",
+        "SHA": "5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a"
+    },
+    "go1.4.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz",
+        "SHA": "332b64236d30a8805fc8dd8b3a269915b4c507fe"
+    },
+    "go1.4.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz",
+        "SHA": "5020af94b52b65cc9b6f11d50a67e4bae07b0aff"
+    },
+    "go1.4.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz",
+        "SHA": "3e871200e13c0b059b14866d428910de0a4c51ed"
+    },
+    "go1.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz",
+        "SHA": "cd82abcb0734f82f7cf2d576c9528cebdafac4c6"
+    },
+    "go1.3.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz",
+        "SHA": "14068fbe349db34b838853a7878621bbd2b24646"
+    },
+    "go1.3.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.3.2.linux-amd64.tar.gz",
+        "SHA": "0e4b6120eee6d45e2e4374dac4fe7607df4cbe42"
+    },
+    "go1.3.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz",
+        "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143"
+    },
+    "go1.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz",
+        "SHA": "b6b154933039987056ac307e20c25fa508a06ba6"
+    },
+    "go1.2.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz",
+        "SHA": "6bd151ca49c435462c8bf019477a6244b958ebb5"
+    },
+    "go1.2.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.1.linux-amd64.tar.gz",
+        "SHA": "d6e9623b8cf566599003dac6c402d03a62f48d98158bfcfc3b0c743b51ad4be6"
+    },
+    "go1.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.linux-amd64.tar.gz",
+        "SHA": "1252ca0aa0a96d53c0592fbc4ea9c9ff5c6b588169c92e08d06da9d89d9d91f2"
+    },
+    "go1.1.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.2.linux-amd64.tar.gz",
+        "SHA": "ad583ff91bd2955fc48d24001785587e3c3b5ce5c09e4971a37028db4c3f6a98"
+    },
+    "go1.1.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.1.linux-amd64.tar.gz",
+        "SHA": "71ff6e7bfd8f59a12f2fc7b7abf5d006fad24664e11e39bec61c2ac84d2e573f"
+    },
+    "go1.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.linux-amd64.tar.gz",
+        "SHA": "2ed0548bc9f9071c24d253f945dd8354bdaa8a9925e48ad5eef586afbf6cfe8a"
+    },
+    "go1.0.3.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.3.linux-amd64.tar.gz",
+        "SHA": "c3389f7069369950bb196d169100d10c5d4eb4ecd5ab5c848d79c3d072244ab6"
+    },
+    "go1.0.2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.2.linux-amd64.tar.gz",
+        "SHA": "f3ceda81d68348fcb472c52371dcc00e2999a10bba3360ca0226d6b81475c8a0"
+    },
+    "go1.0.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.1.linux-amd64.tar.gz",
+        "SHA": "6b28d28da5ba30ca2bef0ffad6935a56b21b866c27acb547931eeb5130a48de4"
+    },
+    "go.go1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go.go1.linux-amd64.tar.gz",
+        "SHA": "9c0cb8a5421727f07d805cb77528d966b8e25cecb239b3ec869c2bf7b5058935"
+    },
+    "jq-linux64": {
+        "URL": "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64",
+        "SHA": "c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d",
+        "LocalName": "jq"
+    },
+    "govendor_linux_amd64": {
+        "URL": "https://github.com/kardianos/govendor/releases/download/v1.0.8/govendor_linux_amd64",
+        "SHA": "90c587c3c2dffa242ed62c62426cd85bae8a74165d5434ccc0c31ee8e25d2588",
+        "LocalName": "govendor"
+    },
+    "glide-v0.12.3-linux-amd64.tar.gz": {
+        "URL": "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz",
+        "SHA": "0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109"
+    },
+    "mercurial-3.9.tar.gz":{
+        "URL": "https://www.mercurial-scm.org/release/mercurial-3.9.tar.gz",
+        "SHA":"834f25dcff44994198fb8a7ba161a6e24204dbd63c8e6270577e06e6cedbdabc"
+    },
+    "gb-0.4.3.tar.gz": {
+        "URL": "https://github.com/constabulary/gb/archive/v0.4.3.tar.gz",
+        "SHA": "480ae2376d20b1c3768b6600d7f9f0c9395071a692c14ea27f9560cccfb3151e"
+    },
+    "errors-0.8.0.tar.gz": {
+        "URL": "https://github.com/pkg/errors/archive/v0.8.0.tar.gz",
+        "SHA": "bacf6c58e490911398cee61742ddc6a90c560733e4c9dcb3d867b17a894c9dd5"
+    }
+}

--- a/files.json
+++ b/files.json
@@ -1,4 +1,8 @@
 {
+    "go1.8beta2.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.8beta2.linux-amd64.tar.gz",
+        "SHA": "4cb9bfb0e82d665871b84070929d6eeb4d51af6bedbc8fdd3df5766e937ef84c"
+    },
     "go1.8beta1.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.8beta1.linux-amd64.tar.gz",
         "SHA": "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d"

--- a/files.json
+++ b/files.json
@@ -160,5 +160,10 @@
     "errors-0.8.0.tar.gz": {
         "URL": "https://github.com/pkg/errors/archive/v0.8.0.tar.gz",
         "SHA": "bacf6c58e490911398cee61742ddc6a90c560733e4c9dcb3d867b17a894c9dd5"
+    },
+    "godep_linux_amd64": {
+        "URL": "https://github.com/tools/godep/releases/download/v75/godep_linux_amd64",
+        "SHA": "4f0b1a01461f2a1892c8065989b8561a88a1c1f09e2a36f01042cd759ea1858c",
+        "LocalName": "godep"
     }
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -4,6 +4,12 @@
 # load environment variables
 # allow apps to specify cgo flags. The literal text '${build_dir}' is substituted for the build directory
 
+if [ -z "${buildpack}" ]; then
+    buildpack=$(cd "$(dirname $0)/.." && pwd)
+fi
+
+DataJSON="${buildpack}/data.json"
+FilesJSON="${buildpack}/files.json"
 godepsJSON="${build}/Godeps/Godeps.json"
 vendorJSON="${build}/vendor/vendor.json"
 glideYAML="${build}/glide.yaml"
@@ -13,6 +19,13 @@ YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m' # No Color
 CURL="curl -s -L --retry 15 --retry-delay 2" # retry for up to 30 seconds
+
+BucketURL="https://heroku-golang-prod.s3.amazonaws.com"
+
+TOOL=""
+# Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile
+GO_LINKER_VALUE=${SOURCE_VERSION}
+
 
 warn() {
     echo -e "${YELLOW} !!    $@${NC}"
@@ -34,16 +47,97 @@ finished() {
     echo "done"
 }
 
+determinLocalFileName() {
+    local fileName="${1}"
+    local localName="jq"
+    if [ "${fileName}" != "jq-linux64" ]; then #jq is special cased here because we can't jq until we have jq'
+        localName="$(<"${FilesJSON}" jq -r '."'${fileName}'".LocalName | if . == null then "'${fileName}'" else . end')"
+    fi
+    echo "${localName}"
+}
+
+downloadFile() {
+    local fileName="${1}"
+    local targetDir="${2}"
+    local xCmd="${3}"
+    local localName="$(determinLocalFileName "${fileName}")"
+    local targetFile="${targetDir}/${localName}"
+
+    mkdir -p "${targetDir}"
+    pushd "${targetDir}" &> /dev/null
+        start "Fetching ${localName}"
+            ${CURL} -O "${BucketURL}/${fileName}"
+            if [ "${fileName}" != "${localName}" ]; then
+                mv "${fileName}" "${localName}"
+            fi
+            if [ -n "${xCmd}" ]; then
+                ${xCmd} ${targetFile}
+            fi
+            if ! SHAValid "${fileName}" "${targetFile}"; then
+                err ""
+                err "Downloaded file (${fileName}) sha does not match recorded SHA"
+                err "Unable to continue."
+                err ""
+                exit 1
+            fi
+        finished
+    popd &> /dev/null
+}
+
+SHAValid() {
+    local fileName="${1}"
+    local targetFile="${2}"
+    local sh=""
+    local sw="$(<"${FilesJSON}" jq -r '"'${fileName}'".SHA' &> /dev/null)"
+    if [ ${#sw} -eq 40 ]; then
+        sh="$(shasum "${targetFile}" | cut -d \  -f 1)"
+    else
+        sh="$(shasum -a256 "${targetFile}" | cut -d \  -f 1)"
+    fi
+    [ "${sh}" = "${sw}" ]
+}
+
+ensureFile() {
+    local fileName="${1}"
+    local targetDir="${2}"
+    local xCmd="${3}"
+    local localName="$(determinLocalFileName "${fileName}")"
+    local targetFile="${targetDir}/${localName}"
+    local download="false"
+    if [ ! -f "${targetFile}" ]; then
+        download="true"
+    elif ! SHAValid "${fileName}" "${targetFile}"; then
+        download="true"
+    fi
+    if [ "${download}" = "true" ]; then
+        downloadFile "${fileName}" "${targetDir}" "${xCmd}"
+    fi
+}
+
+addToPATH() {
+    local targetDir="${1}"
+    if echo "${PATH}" | grep -v "${targetDir}" &> /dev/null; then
+        PATH="${targetDir}:${PATH}"
+    fi
+}
+
+ensureInPath() {
+    local fileName="${1}"
+    local targetDir="${2}"
+    local xCmd="${3:-chmod a+x}"
+    local localName="$(determinLocalFileName "${fileName}")"
+    local targetFile="${targetDir}/${localName}"
+    addToPATH "${targetDir}"
+    ensureFile "${fileName}" "${targetDir}" "${xCmd}"
+}
+
 loadEnvDir() {
     local env_dir="${1}"
-    if [ ! -z "${env_dir}" ]
-    then
+    if [ ! -z "${env_dir}" ]; then
         mkdir -p "${env_dir}"
         env_dir=$(cd "${env_dir}/" && pwd)
-        for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GO_LINKER_SYMBOL GO_LINKER_VALUE GO15VENDOREXPERIMENT GOVERSION GO_INSTALL_PACKAGE_SPEC GO_INSTALL_TOOLS_IN_IMAGE GO_SETUP_GOPATH_IN_IMAGE
-        do
-            if [ -f "${env_dir}/${key}" ]
-            then
+        for key in CGO_CFLAGS CGO_CPPFLAGS CGO_CXXFLAGS CGO_LDFLAGS GO_LINKER_SYMBOL GO_LINKER_VALUE GO15VENDOREXPERIMENT GOVERSION GO_INSTALL_PACKAGE_SPEC GO_INSTALL_TOOLS_IN_IMAGE GO_SETUP_GOPATH_IN_IMAGE; do
+            if [ -f "${env_dir}/${key}" ]; then
                 export "${key}=$(cat "${env_dir}/${key}" | sed -e "s:\${build_dir}:${build}:")"
             fi
         done
@@ -51,43 +145,37 @@ loadEnvDir() {
 }
 
 setGoVersionFromEnvironment() {
-  if test -z "${GOVERSION}"
-  then
-    warn ""
-    warn "'GOVERSION' isn't set, defaulting to '${DefaultGoVersion}'"
-    warn ""
-    warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
-    warn "for future builds"
-    warn ""
-  fi
-  ver=${GOVERSION:-$DefaultGoVersion}
+    if [ -z "${GOVERSION}" ]; then
+        warn ""
+        warn "'GOVERSION' isn't set, defaulting to '${DefaultGoVersion}'"
+        warn ""
+        warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
+        warn "for future builds"
+        warn ""
+    fi
+    ver=${GOVERSION:-$DefaultGoVersion}
 }
 
 determineTool() {
-    if test -f "${godepsJSON}"
-    then
+    if [ -f "${godepsJSON}" ]; then
         TOOL="godep"
         step "Checking Godeps/Godeps.json file."
-        if ! jq -r . < "${godepsJSON}" > /dev/null
-        then
+        if ! jq -r . < "${godepsJSON}" > /dev/null; then
             err "Bad Godeps/Godeps.json file"
-            exit 1
+        exit 1
         fi
         name=$(<${godepsJSON} jq -r .ImportPath)
         ver=${GOVERSION:-$(<${godepsJSON} jq -r .GoVersion)}
         warnGoVersionOverride
-    elif test -f "${vendorJSON}"
-    then
+    elif [ -f "${vendorJSON}" ]; then
         TOOL="govendor"
         step "Checking vendor/vendor.json file."
-        if ! jq -r . < "${vendorJSON}" > /dev/null
-        then
+        if ! jq -r . < "${vendorJSON}" > /dev/null; then
             err "Bad vendor/vendor.json file"
             exit 1
         fi
         name=$(<${vendorJSON} jq -r .rootPath)
-        if [ "$name" = "null" -o -z "$name" ]
-        then
+        if [ "$name" = "null" -o -z "$name" ]; then
             err "The 'rootPath' field is not specified in 'vendor/vendor.json'."
             err "'rootPath' must be set to the root package name used by your repository."
             err "Recent versions of govendor add this field automatically, please upgrade"
@@ -95,26 +183,22 @@ determineTool() {
             err ""
             err "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
             exit 1
-
         fi
         ver=${GOVERSION:-$(<${vendorJSON} jq -r .heroku.goVersion)}
         warnGoVersionOverride
-        if [ "${ver}" =  "null" -o -z "${ver}" ]
-        then
-        ver=${DefaultGoVersion}
-        warn "The 'heroku.goVersion' field is not specified in 'vendor/vendor.json'."
-        warn ""
-        warn "Defaulting to ${ver}"
-        warn ""
-        warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
-        warn ""
+        if [ "${ver}" =  "null" -o -z "${ver}" ]; then
+            ver=${DefaultGoVersion}
+            warn "The 'heroku.goVersion' field is not specified in 'vendor/vendor.json'."
+            warn ""
+            warn "Defaulting to ${ver}"
+            warn ""
+            warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
+            warn ""
         fi
-    elif test -f "${glideYAML}"
-    then
+    elif [ -f "${glideYAML}" ]; then
         TOOL="glide"
         setGoVersionFromEnvironment
-    elif (test -d "$build/src" && test -n "$(find "$build/src" -mindepth 2 -type f -name '*.go' | sed 1q)")
-    then
+    elif [ -d "$build/src" -a -n "$(find "$build/src" -mindepth 2 -type f -name '*.go' | sed 1q)" ]; then
         TOOL="gb"
         setGoVersionFromEnvironment
     else

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -88,7 +88,7 @@ SHAValid() {
     local fileName="${1}"
     local targetFile="${2}"
     local sh=""
-    local sw="$(<"${FilesJSON}" jq -r '"'${fileName}'".SHA' &> /dev/null)"
+    local sw="$(<"${FilesJSON}" jq -r '."'${fileName}'".SHA')"
     if [ ${#sw} -eq 40 ]; then
         sh="$(shasum "${targetFile}" | cut -d \  -f 1)"
     else

--- a/test/run
+++ b/test/run
@@ -562,7 +562,7 @@ testCompileGodepBasicWithTools() {
   assertCaptured "Installing package '.' (default)"
   assertCaptured "github.com/heroku/fixture"
   assertCaptured "Copying go tool chain to"
-  assertCaptured "Copying godep binary"
+  assertNotCaptured "Copying godep binary" #We don't copy the binary when a workspace isn't present
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertFileDoesNotExist ".profile.d/concurrency.sh"

--- a/test/run
+++ b/test/run
@@ -265,7 +265,10 @@ testCompileGodepBasicGo17WithGO15VENDOREXPERIMENT() {
   local env_dir=$(mktmpdir)
   echo '1' > "${env_dir}/GO15VENDOREXPERIMENT"
   compile "godep-basic-go17" ${cache} ${env_dir}
-  assertCapturedError 1 "GO15VENDOREXPERIMENT is set, but is not supported by go1.7"
+  assertCaptured "GO15VENDOREXPERIMENT is set, but is not supported by go"
+  assertCaptured "run \`heroku config:unset GO15VENDOREXPERIMENT\` to unset."
+  assertCapturedSuccess
+  assertCompiledBinaryExists
 }
 
 testDetectGovendorExcluded() {

--- a/test/run
+++ b/test/run
@@ -525,7 +525,7 @@ testCompileGodepLDSymbolGo14Value() {
   echo "main.fixture" > "${env_dir}/GO_LINKER_SYMBOL"
   echo "fixture" > "${env_dir}/GO_LINKER_VALUE"
   compile "godep-ld-symbol-value-go14" ${cache} ${env_dir}
-  assertCaptured "Running: godep go install -v -tags heroku -ldflags -X main.fixture fixture ."
+  assertCaptured "Running: go install -v -tags heroku -ldflags -X main.fixture fixture ." #Nothing vendored
   assertCaptured "Deprecated or unsupported version of go"
   assertCapturedSuccess
   assertCompiledBinaryExists

--- a/test/run
+++ b/test/run
@@ -273,11 +273,11 @@ testDetectGovendorExcluded() {
   assertCaptured "Go"
   assertCapturedSuccess
 }
-testCompuleGovendorExcluded() {
+testCompileGovendorExcluded() {
   compile "govendor-excluded"
   assertCaptured "Checking vendor/vendor.json file."
   assertCaptured "Installing go"
-  assertCaptured "Installing govendor"
+  assertCaptured "Fetching govendor"
   assertCaptured "Installing package '.' (default)"
   assertCaptured "Fetching any unsaved dependencies (govendor sync)"
   assertCaptured "Running: go install -v -tags heroku ."
@@ -397,8 +397,8 @@ testDetectGodepDevelGo() {
 testCompileGodepDevelGo() {
   compile "godep-devel-go"
   assertCaptured "You are using a development build of Go."
-  assertCaptured "Installing devel-15f7a66"
-  assertCaptured "Installing bootstrap Go version go"
+  assertCaptured "Installing bootstrap go"
+  assertCaptured "Downloading development Go version devel-15f7a66"
   assertCaptured "Compiling development Go version devel-15f7a66"
   assertCaptured "Installed Go for linux/amd64"
   assertCaptured "go version devel +15f7a66"


### PR DESCRIPTION
This changes makes it so the buildpack downloads software only from
Heroku's S3 bucket. The SHAs of uploaded files are recorded in
files.json and those SHAs are verified on download.

Additional data about expansion, versions and what not is stored in
data.json.

Both of these changes should make it so that updating Go versions
doesn't require messing that much with the BASH scripts and should
mostly require modifications to the json files.

A new bin `sync-files.sh` is used to sync the contents of the S3 bucket
to local disk, verify the SHAs and upload new files. Deletion of files
from the bucket requires manual work however. `sync-files.sh` downloads
files to `./file-cache`, which is ignored by git.

This includes a lot of cleanups for consistency as well.

/cc @danp @lstoll @bigkevmcd @jkakar 