### PR TITLE
Add info on usage with other vendoring systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ $ git push heroku master
 ## Usage with other vendoring systems
 
 If your vendor system of choice is not listed here, create `vendor/vendor.json`
-with the following contents, adjusted as needed for your project.
+with the following contents, adjusted as needed for your project's root path.
 
 ```json
 {
     "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
-    "rootPath": "github.com/heroku/go-getting-started",
+    "rootPath": "github.com/yourOrg/yourRepo",
     "heroku": {
         "sync": false,
         "install": [ "./..." ],

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ $ heroku config:set GO_INSTALL_PACKAGE_SPEC=./...
 $ git push heroku master
 ```
 
+## Usage with other vendoring systems
+
+If your vendor system of choice is not listed here, create `vendor/vendor.json`
+with the following contents, adjusted as needed for your project.
+
+```json
+{
+    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
+    "rootPath": "github.com/heroku/go-getting-started",
+    "heroku": {
+        "sync": false,
+        "install": [ "./..." ],
+        "goVersion": "go1.8"
+    }
+}
+```
 
 ## Hacking on this Buildpack
 

--- a/README.md
+++ b/README.md
@@ -134,9 +134,7 @@ with the following contents, adjusted as needed for your project's root path.
     "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
     "rootPath": "github.com/yourOrg/yourRepo",
     "heroku": {
-        "sync": false,
-        "install": [ "./..." ],
-        "goVersion": "go1.8"
+        "sync": false
     }
 }
 ```


### PR DESCRIPTION
This gives users a quick path to get started with an existing Go application that they want to run in Heroku.

Closes #166.