### PR TITLE
Namespace cache to prevent deleting other buildpacks' cache data

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,8 +4,9 @@
 set -eo pipefail
 
 mkdir -p "$1" "$2"
+mkdir -p "$2/go-cache"
 build=$(cd "$1/" && pwd)
-cache=$(cd "$2/" && pwd)
+cache=$(cd "$2/go-cache" && pwd)
 env_dir="${3}"
 
 buildpack=$(cd "$(dirname $0)/.." && pwd)


### PR DESCRIPTION
Right now this buildpack will [blow away the entire cache when updating the Go version](https://github.com/jdlehman/heroku-buildpack-go/blob/7801e701b07b7bc5a599e9b7a134fce02cf34d74/bin/compile#L216). It probably isn't ideal to blow away other buildpacks' caches. 

This PR seeks to remedy this by namespacing the cache directory that this buildpack uses by putting it in `$cache/go-cache`. The best part about this change is that it is small and shouldn't break anything.