### PR TITLE
WIP: adding check for vendor directory

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -438,8 +438,10 @@ case "${TOOL}" in
         unset GIT_DIR
         cd "${src}"
 
-        step "Fetching any unsaved dependencies (glide install)"
-        glide install 2>&1
+        if [ ! -d "${src}/vendor" ]; then
+            step "No 'vendor' directory found. Fetching dependencies (glide install)"
+            glide install 2>&1
+        fi
 
         massagePkgSpecForVendor
 


### PR DESCRIPTION
If you use Glide to vendor deps in src/vendor and you commit the deps in your repo (especially when committing deps that are from private repos) don't bother running `glide install` because that will fail.

Currently testing...  I welcome thoughts