### PR TITLE
Add $GLIDE_SKIP_INSTALL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Add $GLIDE_SKIP_INSTALL for when glide users need to skip the `glide install` step.
+
 ## v67 (2017-05-25)
 
 Support go1.8.3 and default to it.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ $ heroku config:set GOVERSION=go1.8   # Will use go1.8.X, Where X is that latest
 $ heroku config:set GOVERSION=go1.7.5 # Pins to go1.7.5
 ```
 
+`glide install` will be run to ensure that all dependencies are properly
+installed. If you need the buildpack to skip the `glide install` you can set
+`$GLIDE_SKIP_INSTALL` to `true`. Example:
+
+``console
+$ heroku config:set GLIDE_SKIP_INSTALL=true
+$ git push heroku master
+```
+
 Installation defaults to `.`. This can be overridden by setting the
 `$GO_INSTALL_PACKAGE_SPEC` environment variable to the package spec you want the
 go tool chain to install. Example:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ heroku config:set GOVERSION=go1.7.5 # Pins to go1.7.5
 installed. If you need the buildpack to skip the `glide install` you can set
 `$GLIDE_SKIP_INSTALL` to `true`. Example:
 
-``console
+```console
 $ heroku config:set GLIDE_SKIP_INSTALL=true
 $ git push heroku master
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -438,8 +438,10 @@ case "${TOOL}" in
         unset GIT_DIR
         cd "${src}"
 
-        step "Fetching any unsaved dependencies (glide install)"
-        glide install 2>&1
+        if [[ "${GLIDE_SKIP_INSTALL}" != "true" ]]; then
+            step "Fetching any unsaved dependencies (glide install)"
+            glide install 2>&1
+        fi
 
         massagePkgSpecForVendor
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -145,6 +145,7 @@ loadEnvDir() {
     envFlags+=("GO_INSTALL_TOOLS_IN_IMAGE")
     envFlags+=("GO_SETUP_GOPATH_IN_IMAGE")
     envFlags+=("GO_TEST_SKIP_BENCHMARK")
+    envFlags+=("GLIDE_SKIP_INSTALL")
     local env_dir="${1}"
     if [ ! -z "${env_dir}" ]; then
         mkdir -p "${env_dir}"


### PR DESCRIPTION
Sometimes a user needs to skip the `glide install` step, setting
$GLIDE_SKIP_INSTALL to `true` skips the step.