### PR TITLE
Dep fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ the following way:
 ```toml
 [metadata.heroku]
   root-package = "github.com/heroku/fixture"
-  go-version = "1.8.3"
+  go-version = "go1.8.3"
   install = [ "./cmd/...", "./foo" ]
   ensure = "false"
   additional-tools = ["github.com/mattes/migrate"]

--- a/bin/compile
+++ b/bin/compile
@@ -385,6 +385,7 @@ export GOPATH
 case "${TOOL}" in
     dep)
         eval "$(setupGOPATH ${name})"
+        depTOML="${src}/Gopkg.toml"
 
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${depTOML} tq '$.metadata.heroku["install"]')}
         if [ -z "${pkgs}" ]; then


### PR DESCRIPTION
@freeformz 

I attempted to update my project to use the new dep support and ran into three issues:
- The README uses the wrong format for Go versions
- The buildpack used the wrong path to Gopkg.toml
- `dep ensure` failed; I had to set `ensure = false`
