### PR TITLE
Add go1.9.1/1.8.4 & default to those VersionExpansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Preliminary [dep](https://github.com/golang/dep) support.
 * Update tq to v0.5
 * Add tq and dep to s3 to ease dep integration.
+* Update go to 1.9.1 & 1.8.4 & default to them - https://groups.google.com/forum/#!msg/golang-nuts/sHfMg4gZNps/a-HDgDDDAAAJ
 
 ## v74 (2017-09-14)
 

--- a/data.json
+++ b/data.json
@@ -3,8 +3,8 @@
     "Supported": ["go1.8.3", "go1.9"],
     "DefaultVersion": "go1.9",
     "VersionExpansion": {
-      "go1.9": "go1.9",
-      "go1.8": "go1.8.3",
+      "go1.9": "go1.9.1",
+      "go1.8": "go1.8.4",
       "go1.7": "go1.7.6",
       "go1.6": "go1.6.4",
       "go1.5": "go1.5.4",

--- a/files.json
+++ b/files.json
@@ -1,4 +1,8 @@
 {
+    "go1.9.1.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz",
+        "SHA": "07d81c6b6b4c2dcf1b5ef7c27aaebd3691cdb40548500941f92b221147c5d9c7"
+    },
     "go1.9.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz",
         "SHA": "d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79"
@@ -18,6 +22,10 @@
     "go1.9beta1.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.9beta1.linux-amd64.tar.gz",
         "SHA": "85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b"
+    },
+    "go1.8.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.8.4.linux-amd64.tar.gz",
+        "SHA": "0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f"
     },
     "go1.8.3.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz",


### PR DESCRIPTION
These versions address the following security vulnerabilities:

https://groups.google.com/forum/#!msg/golang-nuts/sHfMg4gZNps/a-HDgDDDAAAJ