### PR TITLE
Add back missing shebang from bin/detect

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -1,3 +1,4 @@
+#!/bin/bash
 # bin/detect <build-dir>
 set -e
 


### PR DESCRIPTION
This causes the buildpack to completely fail in some build environments and appears to have been inadvertently introduced in 8307d77980ba85d92b354733d3ff5d595773d499.