### PR TITLE
Add go1.9.4 & 1.8.7 and default go1.9/go1.8 to them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add go1.9.4 & 1.8.7 and default go1.9/go1.8 to them.
+
 ## v81 (2018-01-26)
 
 * Bump dep to v0.4.0
@@ -88,7 +90,7 @@ Support go 1.8.1. Default to go1.8.1.
 
 ## v63 (2017-04-04)
 
-Add $GO_TEST_SKIP_BENCHMARK, that when set to anything skips the benchmark during test execution. 
+Add $GO_TEST_SKIP_BENCHMARK, that when set to anything skips the benchmark during test execution.
 
 ## v62 (2017-02-16)
 

--- a/data.json
+++ b/data.json
@@ -67,6 +67,7 @@
       "jq-linux64",
       "go1.9.4.linux-amd64.tar.gz",
       "go1.8.7.linux-amd64.tar.gz",
+      "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",

--- a/data.json
+++ b/data.json
@@ -1,13 +1,13 @@
 {
   "Go": {
-    "Supported": ["go1.8.5", "go1.9.3"],
-    "DefaultVersion": "go1.9.3",
+    "Supported": ["go1.8.7", "go1.9.4"],
+    "DefaultVersion": "go1.9.4",
     "VersionExpansion": {
       "go1.10": "go1.10rc1",
       "go1.9.0": "go1.9",
-      "go1.9": "go1.9.3",
+      "go1.9": "go1.9.4",
       "go1.8.0": "go1.8",
-      "go1.8": "go1.8.5",
+      "go1.8": "go1.8.7",
       "go1.7.0":"go1.7",
       "go1.7": "go1.7.6",
       "go1.6.0":"go1.6",
@@ -65,8 +65,8 @@
   "test": {
     "assets": [
       "jq-linux64",
-      "go1.9.3.linux-amd64.tar.gz",
-      "go1.8.3.linux-amd64.tar.gz",
+      "go1.9.4.linux-amd64.tar.gz",
+      "go1.8.7.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -11,6 +11,10 @@
         "URL": "https://storage.googleapis.com/golang/go1.10beta1.linux-amd64.tar.gz",
         "SHA": "ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055"
     },
+    "go1.9.4.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz",
+        "SHA": "15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779"
+    },
     "go1.9.3.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz",
         "SHA": "a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c"
@@ -42,6 +46,10 @@
     "go1.9beta1.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.9beta1.linux-amd64.tar.gz",
         "SHA": "85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b"
+    },
+    "go1.8.7.linux-amd64.tar.gz": {
+        "URL": "https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz",
+        "SHA": "de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60"
     },
     "go1.8.5.linux-amd64.tar.gz": {
         "URL": "https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz",


### PR DESCRIPTION
Titles says it all.