### PR TITLE
README: clarify stdlib only projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ following contents, adjusted as needed for your project's root path.
 
 ```json
 {
-    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
+    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-support",
     "rootPath": "github.com/yourOrg/yourRepo",
     "heroku": {
         "sync": false

--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ git push heroku master
 
 ## Usage with other vendoring systems
 
-If your vendor system of choice is not listed here, create `vendor/vendor.json`
-with the following contents, adjusted as needed for your project's root path.
+If your vendor system of choice is not listed here or your project only uses 
+packages in the standard library, create `vendor/vendor.json` with the 
+following contents, adjusted as needed for your project's root path.
 
 ```json
 {


### PR DESCRIPTION
Using the directions for other vendoring systems also works for projects that only use packages found in the standard library.