### PR TITLE
Support heroku-18 stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ env:
   matrix:
     - IMAGE=heroku/cedar:14
     - IMAGE=heroku/heroku:16-build
+    - IMAGE=troels/heroku:18-build
   global:
     - secure: eRuNKAX1KXhAevMeng2BliSZnD1drwWUAO73yUqhEPv+vaiwmiUfqTtsco5ud9/f5lL3kupSaC1c6GdDJbn4ISryr67hZ5SAltoS8sBKXglABRFR7Zio5QI5cEqmGCSetMdIHFe5BS3KxKPBVniQydKEf6vLm/gtdU17piNkimU=


### PR DESCRIPTION
As a developer,
Given that I am deploying a Go application to Heroku,
And I am using the heroku-18 stack,
When I git push my code to heroku,
Then my application is built,
And a slug is successfully created.

PS: This is still being developed, but it's time to start supporting it.

