### PR TITLE
bin: add add-version to make files.json adds easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ git push heroku master
 
 ## Usage with other vendoring systems
 
-If your vendor system of choice is not listed here or your project only uses 
-packages in the standard library, create `vendor/vendor.json` with the 
+If your vendor system of choice is not listed here or your project only uses
+packages in the standard library, create `vendor/vendor.json` with the
 following contents, adjusted as needed for your project's root path.
 
 ```json
@@ -285,8 +285,7 @@ make publish # && follow the prompts
 
 ### New Go version
 
-1. Edit `files.json`, and add an entry for the new version, including the SHA,
-   which can be copied from golang.org.
+1. Run `bin/add-version <version>`, eg `bin/add-version go1.11` to update `files.json`.
 1. Update `data.json`, to update the `VersionExpansion` object.
 1. run `make ACCESS_KEY='THE KEY' SECRET_KEY='THE SECRET KEY' sync`.
    This will download everything from the bucket, plus any missing files from

--- a/bin/add-version
+++ b/bin/add-version
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+BASEURL="https://storage.googleapis.com/golang"
+V="$1"
+
+if [ -z "$V" ]; then
+    echo "usage: $0 <go version>" >&2
+    exit 1
+fi
+
+tgz_fn="$V.linux-amd64.tar.gz"
+tgz_url="$BASEURL/$tgz_fn"
+sha256_url="$tgz_url.sha256"
+
+if ! sha256_content="$(curl -s -f "$sha256_url")"; then
+    echo "error: adding $V: couldn't fetch $sha256_url" >&2
+    exit 1
+fi
+
+TGZ_FN="$tgz_fn" TGZ_URL="$tgz_url" SHA256="$sha256_content" jq -S '.[env.TGZ_FN] = {URL: env.TGZ_URL, SHA: env.SHA256 }' files.json > files.json.tmp
+mv files.json.tmp files.json
+
+echo "added $V to files.json"

--- a/files.json
+++ b/files.json
@@ -1,348 +1,348 @@
 {
-    "go1.11beta2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.11beta2.linux-amd64.tar.gz",
-        "SHA": "ccb60f1ae6efe4fcef115db8143eb7f9ba134c63486f47b2c5176706ede35af5"
-    },
-    "go1.11beta1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.11beta1.linux-amd64.tar.gz",
-        "SHA": "df7fe096ffab5d331d35c6d038d2ec0426b45ce17f55a93037e371d3af9d4e6d"
-    },
-    "go1.10.3.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz",
-        "SHA": "fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035"
-    },
-    "go1.9.7.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.7.linux-amd64.tar.gz",
-        "SHA": "88573008f4f6233b81f81d8ccf92234b4f67238df0f0ab173d75a302a1f3d6ee"
-    },
-    "go1.10.2.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz",
-        "SHA": "4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff"
-    },
-    "go1.9.6.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.6.linux-amd64.tar.gz",
-        "SHA": "d1eb07f99ac06906225ac2b296503f06cc257b472e7d7817b8f822fe3766ebfe"
-    },
-    "go1.10.1.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz",
-        "SHA": "72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b"
-    },
-    "go1.9.5.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.5.linux-amd64.tar.gz",
-        "SHA": "d21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7"
-    },
-    "go1.10.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10.linux-amd64.tar.gz",
-        "SHA": "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33"
-    },
-    "go1.10rc2.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10rc2.linux-amd64.tar.gz",
-        "SHA": "6a6a4c0654bc603bcfee4d6ac34a479c260ac61b3edcc8d6773384eb0bda512e"
-    },
-    "go1.10rc1.linux-amd64.tar.gz": {
-        "URL": "https://dl.google.com/go/go1.10rc1.linux-amd64.tar.gz",
-        "SHA": "c10d3cc7760bf3799037bd39027bbffdc568aea21d6fe60fe833373289c7b7c6"
-    },
-    "go1.10beta2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.10beta2.linux-amd64.tar.gz",
-        "SHA": "ab3abb7d731dd5ac7a06d5d5e64ef19946f57d4ce34555d262a87b8899901a93"
-    },
-    "go1.10beta1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.10beta1.linux-amd64.tar.gz",
-        "SHA": "ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055"
-    },
-    "go1.9.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz",
-        "SHA": "15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779"
-    },
-    "go1.9.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz",
-        "SHA": "a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c"
-    },
-    "go1.9.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz",
-        "SHA": "de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b"
-    },
-    "go1.9.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz",
-        "SHA": "07d81c6b6b4c2dcf1b5ef7c27aaebd3691cdb40548500941f92b221147c5d9c7"
-    },
-    "go1.9.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz",
-        "SHA": "d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79"
-    },
-    "go1.9rc2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9rc2.linux-amd64.tar.gz",
-        "SHA": "0d17d440f02505d8fbf6becb777175c242486c1d71046705876dcd20e0574002"
-    },
-    "go1.9rc1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9rc1.linux-amd64.tar.gz",
-        "SHA": "a8ea2ac09878b7a5ac04fe52f144cdc64ab637230638af6975c0f1facbba3ec2"
-    },
-    "go1.9beta2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9beta2.linux-amd64.tar.gz",
-        "SHA": "023f778f063d2234e7c95f572a92298b307807693f7e045a88c90ecd7a08f29d"
-    },
-    "go1.9beta1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.9beta1.linux-amd64.tar.gz",
-        "SHA": "85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b"
-    },
-    "go1.8.7.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz",
-        "SHA": "de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60"
-    },
-    "go1.8.5.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz",
-        "SHA": "4f8aeea2033a2d731f2f75c4d0a4995b357b22af56ed69b3015f4291fca4d42d"
-    },
-    "go1.8.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.4.linux-amd64.tar.gz",
-        "SHA": "0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f"
-    },
-    "go1.8.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz",
-        "SHA": "1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772"
-    },
-    "go1.8.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.2.linux-amd64.tar.gz",
-        "SHA": "5477d6c9a4f96fa120847fafa88319d7b56b5d5068e41c3587eebe248b939be7"
-    },
-    "go1.8.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz",
-        "SHA": "a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994"
-    },
-    "go1.8.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz",
-        "SHA": "53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca"
-    },
-    "go1.8rc3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8rc3.linux-amd64.tar.gz",
-        "SHA": "0ff3faba02ac83920a65b453785771e75f128fbf9ba4ad1d5e72c044103f9c7a"
-    },
-    "go1.8rc2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8rc2.linux-amd64.tar.gz",
-        "SHA": "d62c2d44d0c6b434e3cda12505f3c9fb880757e3396af1e9ba861f7b547cc864"
-    },
-    "go1.8rc1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8rc1.linux-amd64.tar.gz",
-        "SHA": "bb8fe0d81161e4a8b0a8b2145ee5f8a60370baf5d48c07a83f6f09e1ad253bec"
-    },
-    "go1.8beta2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8beta2.linux-amd64.tar.gz",
-        "SHA": "4cb9bfb0e82d665871b84070929d6eeb4d51af6bedbc8fdd3df5766e937ef84c"
-    },
-    "go1.8beta1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.8beta1.linux-amd64.tar.gz",
-        "SHA": "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d"
-    },
-    "go1.7.6.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.6.linux-amd64.tar.gz",
-        "SHA": "ad5808bf42b014c22dd7646458f631385003049ded0bb6af2efc7f1f79fa29ea"
-    },
-    "go1.7.5.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz",
-        "SHA": "2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3"
-    },
-    "go1.7.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz",
-        "SHA": "47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b"
-    },
-    "go1.7.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz",
-        "SHA": "508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e"
-    },
-    "go1.7.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz",
-        "SHA": "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182"
-    },
-    "go1.7.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz",
-        "SHA": "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95"
-    },
-    "go1.6.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.6.4.linux-amd64.tar.gz",
-        "SHA": "b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf"
-    },
-    "go1.6.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz",
-        "SHA": "cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb"
-    },
-    "go1.6.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz",
-        "SHA": "e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a"
-    },
-    "go1.6.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz",
-        "SHA": "6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988"
-    },
-    "go1.6.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz",
-        "SHA": "5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b"
-    },
-    "go1.5.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.5.4.linux-amd64.tar.gz",
-        "SHA": "a3358721210787dc1e06f5ea1460ae0564f22a0fbd91be9dcd947fb1d19b9560"
-    },
-    "go1.5.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz",
-        "SHA": "43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53"
-    },
-    "go1.5.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz",
-        "SHA": "cae87ed095e8d94a81871281d35da7829bd1234e"
-    },
-    "go1.5.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz",
-        "SHA": "46eecd290d8803887dec718c691cc243f2175fe0"
-    },
-    "go1.5.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz",
-        "SHA": "5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a"
-    },
-    "go1.4.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz",
-        "SHA": "332b64236d30a8805fc8dd8b3a269915b4c507fe"
-    },
-    "go1.4.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz",
-        "SHA": "5020af94b52b65cc9b6f11d50a67e4bae07b0aff"
-    },
-    "go1.4.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz",
-        "SHA": "3e871200e13c0b059b14866d428910de0a4c51ed"
-    },
-    "go1.4.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz",
-        "SHA": "cd82abcb0734f82f7cf2d576c9528cebdafac4c6"
-    },
-    "go1.3.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz",
-        "SHA": "14068fbe349db34b838853a7878621bbd2b24646"
-    },
-    "go1.3.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.3.2.linux-amd64.tar.gz",
-        "SHA": "0e4b6120eee6d45e2e4374dac4fe7607df4cbe42"
-    },
-    "go1.3.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz",
-        "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143"
-    },
-    "go1.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz",
-        "SHA": "b6b154933039987056ac307e20c25fa508a06ba6"
-    },
-    "go1.2.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz",
-        "SHA": "6bd151ca49c435462c8bf019477a6244b958ebb5"
-    },
-    "go1.2.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.1.linux-amd64.tar.gz",
-        "SHA": "d6e9623b8cf566599003dac6c402d03a62f48d98158bfcfc3b0c743b51ad4be6"
-    },
-    "go1.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.linux-amd64.tar.gz",
-        "SHA": "1252ca0aa0a96d53c0592fbc4ea9c9ff5c6b588169c92e08d06da9d89d9d91f2"
-    },
-    "go1.1.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.2.linux-amd64.tar.gz",
-        "SHA": "ad583ff91bd2955fc48d24001785587e3c3b5ce5c09e4971a37028db4c3f6a98"
-    },
-    "go1.1.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.1.linux-amd64.tar.gz",
-        "SHA": "71ff6e7bfd8f59a12f2fc7b7abf5d006fad24664e11e39bec61c2ac84d2e573f"
-    },
-    "go1.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.linux-amd64.tar.gz",
-        "SHA": "2ed0548bc9f9071c24d253f945dd8354bdaa8a9925e48ad5eef586afbf6cfe8a"
-    },
-    "go1.0.3.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.3.linux-amd64.tar.gz",
-        "SHA": "c3389f7069369950bb196d169100d10c5d4eb4ecd5ab5c848d79c3d072244ab6"
-    },
-    "go1.0.2.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.2.linux-amd64.tar.gz",
-        "SHA": "f3ceda81d68348fcb472c52371dcc00e2999a10bba3360ca0226d6b81475c8a0"
-    },
-    "go1.0.1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.1.linux-amd64.tar.gz",
-        "SHA": "6b28d28da5ba30ca2bef0ffad6935a56b21b866c27acb547931eeb5130a48de4"
-    },
-    "go.go1.linux-amd64.tar.gz": {
-        "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go.go1.linux-amd64.tar.gz",
-        "SHA": "9c0cb8a5421727f07d805cb77528d966b8e25cecb239b3ec869c2bf7b5058935"
-    },
-    "jq-linux64": {
-        "URL": "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64",
-        "SHA": "c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d",
-        "LocalName": "jq"
-    },
-    "govendor_linux_amd64": {
-        "URL": "https://github.com/kardianos/govendor/releases/download/v1.0.8/govendor_linux_amd64",
-        "SHA": "90c587c3c2dffa242ed62c62426cd85bae8a74165d5434ccc0c31ee8e25d2588",
-        "LocalName": "govendor"
-    },
-    "glide-v0.12.3-linux-amd64.tar.gz": {
-        "URL": "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz",
-        "SHA": "0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109"
-    },
-    "mercurial-3.9.tar.gz":{
-        "URL": "https://www.mercurial-scm.org/release/mercurial-3.9.tar.gz",
-        "SHA":"834f25dcff44994198fb8a7ba161a6e24204dbd63c8e6270577e06e6cedbdabc"
-    },
-    "gb-0.4.4-pre.tar.gz": {
-        "URL": "created manually from commit 137520c0f2217d8b7f934dc307865488ef31b551",
-        "SHA": "f8b3847558d45f8d3a9f8252ab353d5793f1622e78138ec974ea956d7ae4d9d0"
-    },
-    "gb-0.4.4.tar.gz": {
-        "URL": "https://github.com/constabulary/gb/archive/v0.4.4.tar.gz",
-        "SHA": "c7993ae1994ad85cbe35b833d36a137772599fe7ed720edec2d76ebf3fc4313b"
-    },
-    "gb-0.4.3.tar.gz": {
-        "URL": "https://github.com/constabulary/gb/archive/v0.4.3.tar.gz",
-        "SHA": "480ae2376d20b1c3768b6600d7f9f0c9395071a692c14ea27f9560cccfb3151e"
-    },
-    "errors-0.8.0.tar.gz": {
-        "URL": "https://github.com/pkg/errors/archive/v0.8.0.tar.gz",
-        "SHA": "bacf6c58e490911398cee61742ddc6a90c560733e4c9dcb3d867b17a894c9dd5"
-    },
-    "godep_linux_amd64": {
-        "URL": "https://github.com/tools/godep/releases/download/v75/godep_linux_amd64",
-        "SHA": "4f0b1a01461f2a1892c8065989b8561a88a1c1f09e2a36f01042cd759ea1858c",
-        "LocalName": "godep"
-    },
-    "migrate-v3.0.0-linux-amd64.tar.gz": {
-        "URL": "https://github.com/mattes/migrate/releases/download/v3.0.0/migrate.linux-amd64.tar.gz",
-        "SHA": "13fbabe2db0ee3f79611c8171b0596939a3f384025f62925ed136267681e4fbf"
-    },
-    "tq-v0.4-linux-amd64": {
-        "URL": "https://github.com/heroku/tq/releases/download/v0.4/tq-v0.4-linux-amd64",
-        "SHA": "36d33a30e2cafe4b747b8de2449185a13239fb6da2887dde74f3d390fc639e3b",
-        "LocalName": "tq"
-    },
-    "tq-v0.5-linux-amd64": {
-        "URL": "https://github.com/heroku/tq/releases/download/v0.5/tq-v0.5-linux-amd64",
-        "SHA": "f22ab0a1694fb329f96e564f1f0b44876b2a60023ef26b1b42a15fb94287378e",
-        "LocalName": "tq"
-    },
-    "dep-linux-amd64": {
-        "URL": "https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64",
-        "SHA": "408b970c0acacad309d350fc46d718e4a8885b588eca71f4d73e5d6c521ef944",
-        "LocalName": "dep",
-        "Comment": "This is here for backwards compat. Remove after a while."
-    },
-    "dep-v0.3.1-linux-amd64": {
-        "URL": "https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64",
-        "SHA": "408b970c0acacad309d350fc46d718e4a8885b588eca71f4d73e5d6c521ef944",
-        "LocalName": "dep"
-    },
-    "dep-v0.4.0-linux-amd64": {
-        "URL":"https://github.com/golang/dep/releases/download/v0.4.0/dep-linux-amd64",
-        "SHA":"228088ab0fe15dff6779f4e48223a6dd39544d3348b2f43b28b96eae27f341b5",
-        "LocalName": "dep"
-    },
-    "dep-v0.4.1-linux-amd64": {
-        "URL":"https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64",
-        "SHA":"31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315",
-        "LocalName": "dep"
-    }
+  "dep-linux-amd64": {
+    "Comment": "This is here for backwards compat. Remove after a while.",
+    "LocalName": "dep",
+    "SHA": "408b970c0acacad309d350fc46d718e4a8885b588eca71f4d73e5d6c521ef944",
+    "URL": "https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64"
+  },
+  "dep-v0.3.1-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "408b970c0acacad309d350fc46d718e4a8885b588eca71f4d73e5d6c521ef944",
+    "URL": "https://github.com/golang/dep/releases/download/v0.3.1/dep-linux-amd64"
+  },
+  "dep-v0.4.0-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "228088ab0fe15dff6779f4e48223a6dd39544d3348b2f43b28b96eae27f341b5",
+    "URL": "https://github.com/golang/dep/releases/download/v0.4.0/dep-linux-amd64"
+  },
+  "dep-v0.4.1-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315",
+    "URL": "https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64"
+  },
+  "errors-0.8.0.tar.gz": {
+    "SHA": "bacf6c58e490911398cee61742ddc6a90c560733e4c9dcb3d867b17a894c9dd5",
+    "URL": "https://github.com/pkg/errors/archive/v0.8.0.tar.gz"
+  },
+  "gb-0.4.3.tar.gz": {
+    "SHA": "480ae2376d20b1c3768b6600d7f9f0c9395071a692c14ea27f9560cccfb3151e",
+    "URL": "https://github.com/constabulary/gb/archive/v0.4.3.tar.gz"
+  },
+  "gb-0.4.4-pre.tar.gz": {
+    "SHA": "f8b3847558d45f8d3a9f8252ab353d5793f1622e78138ec974ea956d7ae4d9d0",
+    "URL": "created manually from commit 137520c0f2217d8b7f934dc307865488ef31b551"
+  },
+  "gb-0.4.4.tar.gz": {
+    "SHA": "c7993ae1994ad85cbe35b833d36a137772599fe7ed720edec2d76ebf3fc4313b",
+    "URL": "https://github.com/constabulary/gb/archive/v0.4.4.tar.gz"
+  },
+  "glide-v0.12.3-linux-amd64.tar.gz": {
+    "SHA": "0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109",
+    "URL": "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
+  },
+  "go.go1.linux-amd64.tar.gz": {
+    "SHA": "9c0cb8a5421727f07d805cb77528d966b8e25cecb239b3ec869c2bf7b5058935",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go.go1.linux-amd64.tar.gz"
+  },
+  "go1.0.1.linux-amd64.tar.gz": {
+    "SHA": "6b28d28da5ba30ca2bef0ffad6935a56b21b866c27acb547931eeb5130a48de4",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.1.linux-amd64.tar.gz"
+  },
+  "go1.0.2.linux-amd64.tar.gz": {
+    "SHA": "f3ceda81d68348fcb472c52371dcc00e2999a10bba3360ca0226d6b81475c8a0",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.2.linux-amd64.tar.gz"
+  },
+  "go1.0.3.linux-amd64.tar.gz": {
+    "SHA": "c3389f7069369950bb196d169100d10c5d4eb4ecd5ab5c848d79c3d072244ab6",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.0.3.linux-amd64.tar.gz"
+  },
+  "go1.1.1.linux-amd64.tar.gz": {
+    "SHA": "71ff6e7bfd8f59a12f2fc7b7abf5d006fad24664e11e39bec61c2ac84d2e573f",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.1.linux-amd64.tar.gz"
+  },
+  "go1.1.2.linux-amd64.tar.gz": {
+    "SHA": "ad583ff91bd2955fc48d24001785587e3c3b5ce5c09e4971a37028db4c3f6a98",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.2.linux-amd64.tar.gz"
+  },
+  "go1.1.linux-amd64.tar.gz": {
+    "SHA": "2ed0548bc9f9071c24d253f945dd8354bdaa8a9925e48ad5eef586afbf6cfe8a",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.1.linux-amd64.tar.gz"
+  },
+  "go1.10.1.linux-amd64.tar.gz": {
+    "SHA": "72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b",
+    "URL": "https://dl.google.com/go/go1.10.1.linux-amd64.tar.gz"
+  },
+  "go1.10.2.linux-amd64.tar.gz": {
+    "SHA": "4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff",
+    "URL": "https://dl.google.com/go/go1.10.2.linux-amd64.tar.gz"
+  },
+  "go1.10.3.linux-amd64.tar.gz": {
+    "SHA": "fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035",
+    "URL": "https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz"
+  },
+  "go1.10.linux-amd64.tar.gz": {
+    "SHA": "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33",
+    "URL": "https://dl.google.com/go/go1.10.linux-amd64.tar.gz"
+  },
+  "go1.10beta1.linux-amd64.tar.gz": {
+    "SHA": "ec7a10b5bf147a8e06cf64e27384ff3c6d065c74ebd8fdd31f572714f74a1055",
+    "URL": "https://storage.googleapis.com/golang/go1.10beta1.linux-amd64.tar.gz"
+  },
+  "go1.10beta2.linux-amd64.tar.gz": {
+    "SHA": "ab3abb7d731dd5ac7a06d5d5e64ef19946f57d4ce34555d262a87b8899901a93",
+    "URL": "https://storage.googleapis.com/golang/go1.10beta2.linux-amd64.tar.gz"
+  },
+  "go1.10rc1.linux-amd64.tar.gz": {
+    "SHA": "c10d3cc7760bf3799037bd39027bbffdc568aea21d6fe60fe833373289c7b7c6",
+    "URL": "https://dl.google.com/go/go1.10rc1.linux-amd64.tar.gz"
+  },
+  "go1.10rc2.linux-amd64.tar.gz": {
+    "SHA": "6a6a4c0654bc603bcfee4d6ac34a479c260ac61b3edcc8d6773384eb0bda512e",
+    "URL": "https://dl.google.com/go/go1.10rc2.linux-amd64.tar.gz"
+  },
+  "go1.11beta1.linux-amd64.tar.gz": {
+    "SHA": "df7fe096ffab5d331d35c6d038d2ec0426b45ce17f55a93037e371d3af9d4e6d",
+    "URL": "https://storage.googleapis.com/golang/go1.11beta1.linux-amd64.tar.gz"
+  },
+  "go1.11beta2.linux-amd64.tar.gz": {
+    "SHA": "ccb60f1ae6efe4fcef115db8143eb7f9ba134c63486f47b2c5176706ede35af5",
+    "URL": "https://storage.googleapis.com/golang/go1.11beta2.linux-amd64.tar.gz"
+  },
+  "go1.2.1.linux-amd64.tar.gz": {
+    "SHA": "d6e9623b8cf566599003dac6c402d03a62f48d98158bfcfc3b0c743b51ad4be6",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.1.linux-amd64.tar.gz"
+  },
+  "go1.2.2.linux-amd64.tar.gz": {
+    "SHA": "6bd151ca49c435462c8bf019477a6244b958ebb5",
+    "URL": "https://storage.googleapis.com/golang/go1.2.2.linux-amd64.tar.gz"
+  },
+  "go1.2.linux-amd64.tar.gz": {
+    "SHA": "1252ca0aa0a96d53c0592fbc4ea9c9ff5c6b588169c92e08d06da9d89d9d91f2",
+    "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.linux-amd64.tar.gz"
+  },
+  "go1.3.1.linux-amd64.tar.gz": {
+    "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",
+    "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz"
+  },
+  "go1.3.2.linux-amd64.tar.gz": {
+    "SHA": "0e4b6120eee6d45e2e4374dac4fe7607df4cbe42",
+    "URL": "https://storage.googleapis.com/golang/go1.3.2.linux-amd64.tar.gz"
+  },
+  "go1.3.3.linux-amd64.tar.gz": {
+    "SHA": "14068fbe349db34b838853a7878621bbd2b24646",
+    "URL": "https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz"
+  },
+  "go1.3.linux-amd64.tar.gz": {
+    "SHA": "b6b154933039987056ac307e20c25fa508a06ba6",
+    "URL": "https://storage.googleapis.com/golang/go1.3.linux-amd64.tar.gz"
+  },
+  "go1.4.1.linux-amd64.tar.gz": {
+    "SHA": "3e871200e13c0b059b14866d428910de0a4c51ed",
+    "URL": "https://storage.googleapis.com/golang/go1.4.1.linux-amd64.tar.gz"
+  },
+  "go1.4.2.linux-amd64.tar.gz": {
+    "SHA": "5020af94b52b65cc9b6f11d50a67e4bae07b0aff",
+    "URL": "https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz"
+  },
+  "go1.4.3.linux-amd64.tar.gz": {
+    "SHA": "332b64236d30a8805fc8dd8b3a269915b4c507fe",
+    "URL": "https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz"
+  },
+  "go1.4.linux-amd64.tar.gz": {
+    "SHA": "cd82abcb0734f82f7cf2d576c9528cebdafac4c6",
+    "URL": "https://storage.googleapis.com/golang/go1.4.linux-amd64.tar.gz"
+  },
+  "go1.5.1.linux-amd64.tar.gz": {
+    "SHA": "46eecd290d8803887dec718c691cc243f2175fe0",
+    "URL": "https://storage.googleapis.com/golang/go1.5.1.linux-amd64.tar.gz"
+  },
+  "go1.5.2.linux-amd64.tar.gz": {
+    "SHA": "cae87ed095e8d94a81871281d35da7829bd1234e",
+    "URL": "https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz"
+  },
+  "go1.5.3.linux-amd64.tar.gz": {
+    "SHA": "43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53",
+    "URL": "https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz"
+  },
+  "go1.5.4.linux-amd64.tar.gz": {
+    "SHA": "a3358721210787dc1e06f5ea1460ae0564f22a0fbd91be9dcd947fb1d19b9560",
+    "URL": "https://storage.googleapis.com/golang/go1.5.4.linux-amd64.tar.gz"
+  },
+  "go1.5.linux-amd64.tar.gz": {
+    "SHA": "5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a",
+    "URL": "https://storage.googleapis.com/golang/go1.5.linux-amd64.tar.gz"
+  },
+  "go1.6.1.linux-amd64.tar.gz": {
+    "SHA": "6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988",
+    "URL": "https://storage.googleapis.com/golang/go1.6.1.linux-amd64.tar.gz"
+  },
+  "go1.6.2.linux-amd64.tar.gz": {
+    "SHA": "e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a",
+    "URL": "https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz"
+  },
+  "go1.6.3.linux-amd64.tar.gz": {
+    "SHA": "cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb",
+    "URL": "https://storage.googleapis.com/golang/go1.6.3.linux-amd64.tar.gz"
+  },
+  "go1.6.4.linux-amd64.tar.gz": {
+    "SHA": "b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf",
+    "URL": "https://storage.googleapis.com/golang/go1.6.4.linux-amd64.tar.gz"
+  },
+  "go1.6.linux-amd64.tar.gz": {
+    "SHA": "5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b",
+    "URL": "https://storage.googleapis.com/golang/go1.6.linux-amd64.tar.gz"
+  },
+  "go1.7.1.linux-amd64.tar.gz": {
+    "SHA": "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182",
+    "URL": "https://storage.googleapis.com/golang/go1.7.1.linux-amd64.tar.gz"
+  },
+  "go1.7.3.linux-amd64.tar.gz": {
+    "SHA": "508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e",
+    "URL": "https://storage.googleapis.com/golang/go1.7.3.linux-amd64.tar.gz"
+  },
+  "go1.7.4.linux-amd64.tar.gz": {
+    "SHA": "47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b",
+    "URL": "https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz"
+  },
+  "go1.7.5.linux-amd64.tar.gz": {
+    "SHA": "2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3",
+    "URL": "https://storage.googleapis.com/golang/go1.7.5.linux-amd64.tar.gz"
+  },
+  "go1.7.6.linux-amd64.tar.gz": {
+    "SHA": "ad5808bf42b014c22dd7646458f631385003049ded0bb6af2efc7f1f79fa29ea",
+    "URL": "https://storage.googleapis.com/golang/go1.7.6.linux-amd64.tar.gz"
+  },
+  "go1.7.linux-amd64.tar.gz": {
+    "SHA": "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95",
+    "URL": "https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz"
+  },
+  "go1.8.1.linux-amd64.tar.gz": {
+    "SHA": "a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994",
+    "URL": "https://storage.googleapis.com/golang/go1.8.1.linux-amd64.tar.gz"
+  },
+  "go1.8.2.linux-amd64.tar.gz": {
+    "SHA": "5477d6c9a4f96fa120847fafa88319d7b56b5d5068e41c3587eebe248b939be7",
+    "URL": "https://storage.googleapis.com/golang/go1.8.2.linux-amd64.tar.gz"
+  },
+  "go1.8.3.linux-amd64.tar.gz": {
+    "SHA": "1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772",
+    "URL": "https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz"
+  },
+  "go1.8.4.linux-amd64.tar.gz": {
+    "SHA": "0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f",
+    "URL": "https://storage.googleapis.com/golang/go1.8.4.linux-amd64.tar.gz"
+  },
+  "go1.8.5.linux-amd64.tar.gz": {
+    "SHA": "4f8aeea2033a2d731f2f75c4d0a4995b357b22af56ed69b3015f4291fca4d42d",
+    "URL": "https://storage.googleapis.com/golang/go1.8.5.linux-amd64.tar.gz"
+  },
+  "go1.8.7.linux-amd64.tar.gz": {
+    "SHA": "de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60",
+    "URL": "https://storage.googleapis.com/golang/go1.8.7.linux-amd64.tar.gz"
+  },
+  "go1.8.linux-amd64.tar.gz": {
+    "SHA": "53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca",
+    "URL": "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz"
+  },
+  "go1.8beta1.linux-amd64.tar.gz": {
+    "SHA": "768d8d73ccea69c9a0941f9ef2333b1ff8c82120abfcdedd4e91af039c674a8d",
+    "URL": "https://storage.googleapis.com/golang/go1.8beta1.linux-amd64.tar.gz"
+  },
+  "go1.8beta2.linux-amd64.tar.gz": {
+    "SHA": "4cb9bfb0e82d665871b84070929d6eeb4d51af6bedbc8fdd3df5766e937ef84c",
+    "URL": "https://storage.googleapis.com/golang/go1.8beta2.linux-amd64.tar.gz"
+  },
+  "go1.8rc1.linux-amd64.tar.gz": {
+    "SHA": "bb8fe0d81161e4a8b0a8b2145ee5f8a60370baf5d48c07a83f6f09e1ad253bec",
+    "URL": "https://storage.googleapis.com/golang/go1.8rc1.linux-amd64.tar.gz"
+  },
+  "go1.8rc2.linux-amd64.tar.gz": {
+    "SHA": "d62c2d44d0c6b434e3cda12505f3c9fb880757e3396af1e9ba861f7b547cc864",
+    "URL": "https://storage.googleapis.com/golang/go1.8rc2.linux-amd64.tar.gz"
+  },
+  "go1.8rc3.linux-amd64.tar.gz": {
+    "SHA": "0ff3faba02ac83920a65b453785771e75f128fbf9ba4ad1d5e72c044103f9c7a",
+    "URL": "https://storage.googleapis.com/golang/go1.8rc3.linux-amd64.tar.gz"
+  },
+  "go1.9.1.linux-amd64.tar.gz": {
+    "SHA": "07d81c6b6b4c2dcf1b5ef7c27aaebd3691cdb40548500941f92b221147c5d9c7",
+    "URL": "https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz"
+  },
+  "go1.9.2.linux-amd64.tar.gz": {
+    "SHA": "de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b",
+    "URL": "https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz"
+  },
+  "go1.9.3.linux-amd64.tar.gz": {
+    "SHA": "a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c",
+    "URL": "https://storage.googleapis.com/golang/go1.9.3.linux-amd64.tar.gz"
+  },
+  "go1.9.4.linux-amd64.tar.gz": {
+    "SHA": "15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779",
+    "URL": "https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz"
+  },
+  "go1.9.5.linux-amd64.tar.gz": {
+    "SHA": "d21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7",
+    "URL": "https://storage.googleapis.com/golang/go1.9.5.linux-amd64.tar.gz"
+  },
+  "go1.9.6.linux-amd64.tar.gz": {
+    "SHA": "d1eb07f99ac06906225ac2b296503f06cc257b472e7d7817b8f822fe3766ebfe",
+    "URL": "https://storage.googleapis.com/golang/go1.9.6.linux-amd64.tar.gz"
+  },
+  "go1.9.7.linux-amd64.tar.gz": {
+    "SHA": "88573008f4f6233b81f81d8ccf92234b4f67238df0f0ab173d75a302a1f3d6ee",
+    "URL": "https://storage.googleapis.com/golang/go1.9.7.linux-amd64.tar.gz"
+  },
+  "go1.9.linux-amd64.tar.gz": {
+    "SHA": "d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79",
+    "URL": "https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz"
+  },
+  "go1.9beta1.linux-amd64.tar.gz": {
+    "SHA": "85719a2c704ad1352052e185c760d7c65b9d8a18b491287a7e5f6775ccc27d3b",
+    "URL": "https://storage.googleapis.com/golang/go1.9beta1.linux-amd64.tar.gz"
+  },
+  "go1.9beta2.linux-amd64.tar.gz": {
+    "SHA": "023f778f063d2234e7c95f572a92298b307807693f7e045a88c90ecd7a08f29d",
+    "URL": "https://storage.googleapis.com/golang/go1.9beta2.linux-amd64.tar.gz"
+  },
+  "go1.9rc1.linux-amd64.tar.gz": {
+    "SHA": "a8ea2ac09878b7a5ac04fe52f144cdc64ab637230638af6975c0f1facbba3ec2",
+    "URL": "https://storage.googleapis.com/golang/go1.9rc1.linux-amd64.tar.gz"
+  },
+  "go1.9rc2.linux-amd64.tar.gz": {
+    "SHA": "0d17d440f02505d8fbf6becb777175c242486c1d71046705876dcd20e0574002",
+    "URL": "https://storage.googleapis.com/golang/go1.9rc2.linux-amd64.tar.gz"
+  },
+  "godep_linux_amd64": {
+    "LocalName": "godep",
+    "SHA": "4f0b1a01461f2a1892c8065989b8561a88a1c1f09e2a36f01042cd759ea1858c",
+    "URL": "https://github.com/tools/godep/releases/download/v75/godep_linux_amd64"
+  },
+  "govendor_linux_amd64": {
+    "LocalName": "govendor",
+    "SHA": "90c587c3c2dffa242ed62c62426cd85bae8a74165d5434ccc0c31ee8e25d2588",
+    "URL": "https://github.com/kardianos/govendor/releases/download/v1.0.8/govendor_linux_amd64"
+  },
+  "jq-linux64": {
+    "LocalName": "jq",
+    "SHA": "c6b3a7d7d3e7b70c6f51b706a3b90bd01833846c54d32ca32f0027f00226ff6d",
+    "URL": "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64"
+  },
+  "mercurial-3.9.tar.gz": {
+    "SHA": "834f25dcff44994198fb8a7ba161a6e24204dbd63c8e6270577e06e6cedbdabc",
+    "URL": "https://www.mercurial-scm.org/release/mercurial-3.9.tar.gz"
+  },
+  "migrate-v3.0.0-linux-amd64.tar.gz": {
+    "SHA": "13fbabe2db0ee3f79611c8171b0596939a3f384025f62925ed136267681e4fbf",
+    "URL": "https://github.com/mattes/migrate/releases/download/v3.0.0/migrate.linux-amd64.tar.gz"
+  },
+  "tq-v0.4-linux-amd64": {
+    "LocalName": "tq",
+    "SHA": "36d33a30e2cafe4b747b8de2449185a13239fb6da2887dde74f3d390fc639e3b",
+    "URL": "https://github.com/heroku/tq/releases/download/v0.4/tq-v0.4-linux-amd64"
+  },
+  "tq-v0.5-linux-amd64": {
+    "LocalName": "tq",
+    "SHA": "f22ab0a1694fb329f96e564f1f0b44876b2a60023ef26b1b42a15fb94287378e",
+    "URL": "https://github.com/heroku/tq/releases/download/v0.5/tq-v0.5-linux-amd64"
+  }
 }


### PR DESCRIPTION
Adds `bin/add-version` to do the work of finding a release's sha256 and adding to `files.json`.

Uses `jq -S` so adds a commit which applies that to `files.json` to start.