### PR TITLE
Add some module safeguards / info

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ TQVersion="$(<${DataJSON} jq -r '.tq.DefaultVersion')"
 
 # For specified versions of Go we need to keep concurrency.sh
 needConcurrency() {
-    <"${DataJSON}" jq -e '.Go.NeedsConcurrency | indices(["'${1}'"]) | length | if . == 0 then false else true end' &> /dev/null
+    <"${DataJSON}" jq -e '.Go.NeedsConcurrency | any(. == "'${1}'")' &> /dev/null
 }
 
 handleDefaultPkgSpec() {
@@ -492,7 +492,7 @@ case "${TOOL}" in
             fi
         fi
         # Warn that GO15VENDOREXPIERMENT is set, but the go version does not support it.
-        if <"${DataJSON}" jq -e '.Go.SupportsVendorExperiment | indices(["'${ver}'"]) | length | if . == 0 then true else false end' &> /dev/null; then
+        if ! <"${DataJSON}" jq -e '.Go.SupportsVendorExperiment | any(. == "'${ver}'")' &> /dev/null; then
             if [ -n "${GO15VENDOREXPERIMENT}" ]; then
                 warn ""
                 warn "GO15VENDOREXPERIMENT is set, but is not supported by ${ver}"

--- a/bin/compile
+++ b/bin/compile
@@ -108,10 +108,33 @@ expandVer() {
 # Report deprecated versions to user
 # Use after expandVer
 reportVer() {
-    if <"${DataJSON}" jq -e '.Go.Supported | indices(["'${1}'"]) | length | if . > 0 then true else false end' &> /dev/null; then
+    local ver="${1}"
+
+    if [ "${TOOL}" = "gomodules" ]; then
+        warn ""
+        warn "Go modules are an experimental feature of go1.11"
+        warn "Any issues building code that uses Go modules should be"
+        warn "reported via: https://github.com/heroku/heroku-buildpack-go/issues"
+        warn ""
+        warn "Additional documentation for using Go modules with this buildpack"
+        warn "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
+        warn ""
+        if ! <"${DataJSON}" jq  -e '.Go.SupportsModuleExperiment | any(. == "'${ver}'")' &> /dev/null; then
+            err "You are using ${ver}, which does not support the Go modules experiment"
+            err ""
+            err "Please add the following comment to your go.mod file to specify go1.11:"
+            err "// +heroku goVersion go1.11"
+            err ""
+            err "Then commit and push again."
+           exit 1
+        fi
+    fi
+
+    if <"${DataJSON}" jq  -e '.Go.Supported | any(. == "'${ver}'")' &> /dev/null; then
         return
     fi
-    case $1 in
+
+    case $ver in
         devel*)
             warn ""
             warn "You are using a development build of Go."
@@ -123,7 +146,7 @@ reportVer() {
         ;;
         *)
             warn ""
-            warn "Deprecated or unsupported version of go ($1)"
+            warn "Deprecated or unsupported version of go ($ver)"
             warn "See https://devcenter.heroku.com/articles/go-support#go-versions for supported version information."
             warn ""
         ;;

--- a/data.json
+++ b/data.json
@@ -39,6 +39,10 @@
     "SupportsVendorExperiment": [
       "go1.5", "go1.5.1", "go1.5.2", "go1.5.3", "go1.5.4",
       "go1.6", "go1.6.1", "go1.6.2", "go1.6.3", "go1.6.4"
+    ],
+    "SupportsModuleExperiment": [
+      "go1.11beta2", "go1.11beta3", "go1.11rc1", "go1.11rc2",
+      "go1.11"
     ]
   },
   "Dep": {

--- a/test/fixtures/mod-old-version/Procfile
+++ b/test/fixtures/mod-old-version/Procfile
@@ -1,0 +1,1 @@
+web: fixture

--- a/test/fixtures/mod-old-version/go.mod
+++ b/test/fixtures/mod-old-version/go.mod
@@ -1,0 +1,3 @@
+// +heroku goVersion go1.10
+
+module github.com/heroku/fixture

--- a/test/fixtures/mod-old-version/main.go
+++ b/test/fixtures/mod-old-version/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModOldVersion() {
+  fixture "mod-old-version"
+
+  assertDetected
+
+  compile
+  assertCapturedError 1 "Please add the following comment to your go.mod file to specify"
+}
+
 testModInstall() {
   fixture "mod-install"
 


### PR DESCRIPTION
With this you should get a better error in case you are trying to use modules with a version of Go that we know doesn't support modules.

