### PR TITLE
Add Go1.11 and Go1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add go1.11 and mark it as supported
 
 ## v91 (2018-08-24)
 * Add go1.11rc2 (unsupported) for experimenters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add go1.11 and mark it as supported
+* Add go1.10.4 and make it the default, supported version
 
 ## v91 (2018-08-24)
 * Add go1.11rc2 (unsupported) for experimenters

--- a/data.json
+++ b/data.json
@@ -1,12 +1,12 @@
 {
   "Go": {
-    "Supported": ["go1.9.7", "go1.10.3", "go1.11"],
-    "DefaultVersion": "go1.10.3",
+    "Supported": ["go1.9.7", "go1.10.4", "go1.11"],
+    "DefaultVersion": "go1.10.4",
     "VersionExpansion": {
       "go1.11.0": "go1.11",
       "go1.11": "go1.11",
       "go1.10.0": "go1.10",
-      "go1.10": "go1.10.3",
+      "go1.10": "go1.10.4",
       "go1.9.0": "go1.9",
       "go1.9": "go1.9.7",
       "go1.8.0": "go1.8",
@@ -76,7 +76,7 @@
     "assets": [
       "jq-linux64",
       "go1.11.linux-amd64.tar.gz",
-      "go1.10.3.linux-amd64.tar.gz",
+      "go1.10.4.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",

--- a/data.json
+++ b/data.json
@@ -1,10 +1,10 @@
 {
   "Go": {
-    "Supported": ["go1.9.7", "go1.10.3"],
+    "Supported": ["go1.9.7", "go1.10.3", "go1.11"],
     "DefaultVersion": "go1.10.3",
     "VersionExpansion": {
-      "go1.11.0": "go1.11rc2",
-      "go1.11": "go1.11rc2",
+      "go1.11.0": "go1.11",
+      "go1.11": "go1.11",
       "go1.10.0": "go1.10",
       "go1.10": "go1.10.3",
       "go1.9.0": "go1.9",
@@ -75,7 +75,7 @@
   "test": {
     "assets": [
       "jq-linux64",
-      "go1.11rc2.linux-amd64.tar.gz",
+      "go1.11.linux-amd64.tar.gz",
       "go1.10.3.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -116,6 +116,10 @@
     "SHA": "7d3fc1dec64b056cbd22ffd80bb9733725c1296aabfd58cc92bab8a5c6560e03",
     "URL": "https://storage.googleapis.com/golang/go1.11rc2.linux-amd64.tar.gz"
   },
+  "go1.11.linux-amd64.tar.gz": {
+    "SHA": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
+    "URL": "https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz"
+  },
   "go1.2.1.linux-amd64.tar.gz": {
     "SHA": "d6e9623b8cf566599003dac6c402d03a62f48d98158bfcfc3b0c743b51ad4be6",
     "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.1.linux-amd64.tar.gz"

--- a/files.json
+++ b/files.json
@@ -80,6 +80,10 @@
     "SHA": "fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035",
     "URL": "https://dl.google.com/go/go1.10.3.linux-amd64.tar.gz"
   },
+  "go1.10.4.linux-amd64.tar.gz": {
+    "SHA": "fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec",
+    "URL": "https://dl.google.com/go/go1.10.4.linux-amd64.tar.gz"
+  },
   "go1.10.linux-amd64.tar.gz": {
     "SHA": "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33",
     "URL": "https://dl.google.com/go/go1.10.linux-amd64.tar.gz"


### PR DESCRIPTION
Make go1.10.4 the default for now until there is a little more time to kick the tires.