### PR TITLE
Adjust version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Be clearer about what version of go is chosen if none is specified. Addresses #266.
+* Handle version stuff in the right place for go modules.
 
 ## v92 (2018-08-27)
 * Add go1.11 and mark it as supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Be clearer about what version of go is chosen if none is specified. Addresses #266.
 
 ## v92 (2018-08-27)
 * Add go1.11 and mark it as supported

--- a/README.md
+++ b/README.md
@@ -61,12 +61,9 @@ comments to track Heroku build specific configuration which is encoded in the
 following way:
 
 - `// +heroku goVersion <version>`: the major version of go you would like
-  Heroku to use when compiling your code. If not specified this defaults to the
-  buildpack's [DefaultVersion]. Exact versions (ex `go1.9.4`) can also be
-  specified if needed, but is not generally recommended. Since Go doesn't
-  release `.0` versions, specifying a `.0` version will pin your code to the
-  initial release of the given major version (ex `go1.10.0` == `go1.10` w/o auto
-  updating to `go1.10.1` when it becomes available).
+  Heroku to use when compiling your code. If not specified this currently
+  defaults to `go1.11`. Specifying a version < go1.11 will cause a build error
+  because modules are not supported by older versions of go.
 
   Example: `// +heroku goVersion go1.11`
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Creating polar-waters-4785...
 $ git push heroku master
 ...
 -----> Go app detected
------> Installing go1.9... done
------> Running: go install -tags heroku ./...
+-----> Installing go1.11... done
+-----> Running: go install -tags heroku .
 -----> Discovering process types
        Procfile declares types -> web
 
@@ -60,13 +60,13 @@ constraint](https://golang.org/pkg/go/build/#hdr-Build_Constraints) style
 comments to track Heroku build specific configuration which is encoded in the
 following way:
 
-- `// +heroku goVersion <version>`: the major version of go you would like Heroku
-  to use when compiling your code. If not specified defaults to the most recent
-  supported version of Go. Exact versions (ex `go1.9.4`) can also be specified
-  if needed, but is not generally recommended. Since Go doesn't release `.0`
-  versions, specifying a `.0` version will pin your code to the initial release
-  of the given major version (ex `go1.10.0` == `go1.10` w/o auto updating to
-  `go1.10.1` when it becomes available).
+- `// +heroku goVersion <version>`: the major version of go you would like
+  Heroku to use when compiling your code. If not specified this defaults to the
+  buildpack's [DefaultVersion]. Exact versions (ex `go1.9.4`) can also be
+  specified if needed, but is not generally recommended. Since Go doesn't
+  release `.0` versions, specifying a `.0` version will pin your code to the
+  initial release of the given major version (ex `go1.10.0` == `go1.10` w/o auto
+  updating to `go1.10.1` when it becomes available).
 
   Example: `// +heroku goVersion go1.11`
 
@@ -94,8 +94,12 @@ the following way:
   .`. There is no default for this and it must be specified.
 
 - `metadata.heroku['go-version']` (String): the major version of go you would
-  like Heroku to use when compiling your code. if not specified defaults to the
-  most recent supported version of Go.
+  like Heroku to use when compiling your code. If not specified this defaults to
+  the buildpack's [DefaultVersion]. Exact versions (ex `go1.9.4`) can also be
+  specified if needed, but is not generally recommended. Since Go doesn't
+  release `.0` versions, specifying a `.0` version will pin your code to the
+  initial release of the given major version (ex `go1.10.0` == `go1.10` w/o auto
+  updating to `go1.10.1` when it becomes available).
 
 - `metadata.heroku['install']` (Array of Strings): a list of the packages you
   want to install. If not specified, this defaults to `["."]`. Other common
@@ -140,8 +144,12 @@ top level json keys:
    govendor to modify a dependency.
 
 - `heroku.goVersion` (String): the major version of go you would like Heroku to
-  use when compiling your code: if not specified defaults to the most recent
-  supported version of Go.
+  use when compiling your code. If not specified this defaults to the
+  buildpack's [DefaultVersion]. Exact versions (ex `go1.9.4`) can also be
+  specified if needed, but is not generally recommended. Since Go doesn't
+  release `.0` versions, specifying a `.0` version will pin your code to the
+  initial release of the given major version (ex `go1.10.0` == `go1.10` w/o auto
+  updating to `go1.10.1` when it becomes available).
 
 - `heroku.install` (Array of Strings): a list of the packages you want to install.
   If not specified, this defaults to `["."]`. Other common choices are:
@@ -184,11 +192,16 @@ control the build process.
 
 The base package name is determined by running `glide name`.
 
-The Go version used to compile code defaults to the latest released version of Go.
-This can be overridden by the `$GOVERSION` environment variable. Setting
-`$GOVERSION` to a major version will result in the buildpack using the
-latest released minor version in that series. Setting `$GOVERSION` to a specific
-minor Go version will pin Go to that version. Examples:
+The Go version used to compile code defaults to the buildpack's
+[DefaultVersion]. This can be overridden by the `$GOVERSION` environment
+variable. Setting `$GOVERSION` to a major version will result in the buildpack
+using the latest released minor version in that series. Setting `$GOVERSION` to
+a specific minor Go version will pin Go to that version. Since Go doesn't
+release `.0` versions, specifying a `.0` version will pin your code to the
+initial release of the given major version (ex `go1.10.0` == `go1.10` w/o auto
+updating to `go1.10.1` when it becomes available).
+
+Examples:
 
 ```console
 heroku config:set GOVERSION=go1.9   # Will use go1.9.X, Where X is that latest minor release in the 1.9 series
@@ -341,3 +354,4 @@ make publish # && follow the prompts
 [gopgsqldriver]: https://github.com/jbarham/gopgsqldriver
 [glide]: https://github.com/Masterminds/glide
 [gomodules]: https://github.com/golang/go/wiki/Modules
+[DefaultVersion]: https://github.com/heroku/heroku-buildpack-go/blob/master/data.json#L4

--- a/bin/compile
+++ b/bin/compile
@@ -110,27 +110,6 @@ expandVer() {
 # Use after expandVer
 reportVer() {
     local ver="${1}"
-
-    if [ "${TOOL}" = "gomodules" ]; then
-        warn ""
-        warn "Go modules are an experimental feature of go1.11"
-        warn "Any issues building code that uses Go modules should be"
-        warn "reported via: https://github.com/heroku/heroku-buildpack-go/issues"
-        warn ""
-        warn "Additional documentation for using Go modules with this buildpack"
-        warn "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
-        warn ""
-        if ! <"${DataJSON}" jq  -e '.Go.SupportsModuleExperiment | any(. == "'${ver}'")' &> /dev/null; then
-            err "You are using ${ver}, which does not support the Go modules experiment"
-            err ""
-            err "Please add the following comment to your go.mod file to specify go1.11:"
-            err "// +heroku goVersion go1.11"
-            err ""
-            err "Then commit and push again."
-           exit 1
-        fi
-    fi
-
     if <"${DataJSON}" jq  -e '.Go.Supported | any(. == "'${ver}'")' &> /dev/null; then
         return
     fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -281,7 +281,8 @@ determineTool() {
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
         warnGoVersionOverride
         if [ -z "${ver}" ]; then
-            ver=${DefaultGoVersion}
+            #ver=${DefaultGoVersion}
+            ver="go1.11"
             warn "The go.mod file for this project does not specify a Go version"
             warn ""
             warn "Defaulting to ${ver}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -270,8 +270,34 @@ setGoVersionFromEnvironment() {
 determineTool() {
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
+        warn ""
+        warn "Go modules are an experimental feature of go1.11"
+        warn "Any issues building code that uses Go modules should be"
+        warn "reported via: https://github.com/heroku/heroku-buildpack-go/issues"
+        warn ""
+        warn "Additional documentation for using Go modules with this buildpack"
+        warn "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
+        warn ""
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
         warnGoVersionOverride
+        if [ -z "${ver}" ]; then
+            ver=${DefaultGoVersion}
+            warn "The go.mod file for this project does not specify a Go version"
+            warn ""
+            warn "Defaulting to ${ver}"
+            warn ""
+            warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
+            warn ""
+        fi
+        if ! <"${DataJSON}" jq  -e '.Go.SupportsModuleExperiment | any(. == "'${ver}'")' &> /dev/null; then
+            err "You are using ${ver}, which does not support the Go modules experiment"
+            err ""
+            err "Please add the following comment to your go.mod file to specify go1.11:"
+            err "// +heroku goVersion go1.11"
+            err ""
+            err "Then commit and push again."
+           exit 1
+        fi
     elif [ -f "${depTOML}" ]; then
         TOOL="dep"
         ensureInPath "tq-${TQVersion}-linux-amd64" "${cache}/.tq/bin"

--- a/test/fixtures/mod-no-version/Procfile
+++ b/test/fixtures/mod-no-version/Procfile
@@ -1,0 +1,1 @@
+web: fixture

--- a/test/fixtures/mod-no-version/go.mod
+++ b/test/fixtures/mod-no-version/go.mod
@@ -1,0 +1,1 @@
+module github.com/heroku/fixture

--- a/test/fixtures/mod-no-version/main.go
+++ b/test/fixtures/mod-no-version/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,29 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+
+testModNoVersion() {
+  fixture "mod-no-version"
+
+  assertDetected
+
+  compile
+  assertCaptured "Go modules are an experimental feature of go1.11"
+  assertCaptured "Any issues building code that uses Go modules should be"
+  assertCaptured "reported via: https://github.com/heroku/heroku-buildpack-go/issues" 
+  assertCaptured "Additional documentation for using Go modules with this buildpack"
+  assertCaptured "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
+  assertCaptured "The go.mod file for this project does not specify a Go version"
+  assertCaptured "Defaulting to ${DEFAULT_GO_VERSION}"
+  assertCaptured "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
+
+  assertCapturedError 1 "You are using ${DEFAULT_GO_VERSION}, which does not support the Go modules experiment"
+  assertCapturedError 1 "Please add the following comment to your go.mod file to specify go1.11:"
+  assertCapturedError 1 "// +heroku goVersion go1.11"
+  assertCapturedError 1 "Then commit and push again."
+  assertCapturedError 1 "Please add the following comment to your go.mod file to specify"
+}
+
 testModOldVersion() {
   fixture "mod-old-version"
 

--- a/test/run
+++ b/test/run
@@ -14,14 +14,11 @@ testModNoVersion() {
   assertCaptured "Additional documentation for using Go modules with this buildpack"
   assertCaptured "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
   assertCaptured "The go.mod file for this project does not specify a Go version"
-  assertCaptured "Defaulting to ${DEFAULT_GO_VERSION}"
+  assertCaptured "Defaulting to go1.11"
   assertCaptured "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
 
-  assertCapturedError 1 "You are using ${DEFAULT_GO_VERSION}, which does not support the Go modules experiment"
-  assertCapturedError 1 "Please add the following comment to your go.mod file to specify go1.11:"
-  assertCapturedError 1 "// +heroku goVersion go1.11"
-  assertCapturedError 1 "Then commit and push again."
-  assertCapturedError 1 "Please add the following comment to your go.mod file to specify"
+  assertCapturedSuccess
+  assertCompiledBinaryExists
 }
 
 testModOldVersion() {

--- a/test/utils
+++ b/test/utils
@@ -7,6 +7,7 @@ oneTimeSetUp()
 {
    TEST_SUITE_CACHE="$(mktemp -d ${SHUNIT_TMPDIR}/test_suite_cache.XXXX)"
    BUILDPACK_HOME="/buildpack"
+   DEFAULT_GO_VERSION=$(head < $BUILDPACK_HOME/data.json | grep DefaultVersion | cut -d : -f 2 | cut -d , -f 1 | sed -e s:\"::g -e s:\ ::g)
 }
 
 oneTimeTearDown()


### PR DESCRIPTION
Closes #266

Basically the buildpack wasn't entirely accurate when it said "the latest supported version", when in reality it uses the DefaultVersion specified in data.json when no version is specified.

Additionally the version message handling wasn't in the right place for go modules.

And when detecting go.mod, default to go1.11 for now.

This PR fixes those two things.