### PR TITLE
Fix go modules support for projects without explicit Procfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Remove the need for Procfiles in simple situations for go modules
+
 ## v93 (2018-08-30)
 * Be clearer about what version of go is chosen if none is specified. Addresses #266.
 * Handle version stuff in the right place for go modules.

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -279,6 +279,7 @@ determineTool() {
         warn "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
         warn ""
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
+        name=$(awk '{ if ($1 == "module" ) { print $2; exit } }' ${goMOD} | cut -d/ -f3)
         warnGoVersionOverride
         if [ -z "${ver}" ]; then
             #ver=${DefaultGoVersion}

--- a/test/fixtures/mod-basic-wo-procfile/go.mod
+++ b/test/fixtures/mod-basic-wo-procfile/go.mod
@@ -1,0 +1,3 @@
+// +heroku goVersion go1.11
+
+module github.com/heroku/fixture

--- a/test/fixtures/mod-basic-wo-procfile/main.go
+++ b/test/fixtures/mod-basic-wo-procfile/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/test/run
+++ b/test/run
@@ -10,7 +10,7 @@ testModNoVersion() {
   compile
   assertCaptured "Go modules are an experimental feature of go1.11"
   assertCaptured "Any issues building code that uses Go modules should be"
-  assertCaptured "reported via: https://github.com/heroku/heroku-buildpack-go/issues" 
+  assertCaptured "reported via: https://github.com/heroku/heroku-buildpack-go/issues"
   assertCaptured "Additional documentation for using Go modules with this buildpack"
   assertCaptured "can be found here: https://github.com/heroku/heroku-buildpack-go#go-module-specifics"
   assertCaptured "The go.mod file for this project does not specify a Go version"
@@ -77,6 +77,16 @@ testModBasic() {
   #assertCaptured "github.com/heroku/fixture"
   assertCapturedSuccess
   assertCompiledBinaryExists
+}
+
+testModBasicWithoutProcfile() {
+  fixture "mod-basic-wo-procfile"
+
+  assertDetected
+
+  compile
+  assertCompiledBinaryExists
+  assertFile "web: fixture" "Procfile"
 }
 
 testModDeps() {


### PR DESCRIPTION
The name of the binary is determined by a module name from `go.mod` file.

Without this change, go modules support is inconsistent with the rest dependency toolchains. It doesn't support implicit Procfile creation like for instance `dep`.
