### PR TITLE
Fix default pkg spec warning message when using dep

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -42,7 +42,7 @@ handleDefaultPkgSpec() {
                 warn ""
             ;;
             dep)
-                warn "To install a different package spec set 'metadata.heroku.pkg-spec' in 'Gopkg.toml'"
+                warn "To install a different package spec set 'metadata.heroku.install' in 'Gopkg.toml'"
                 warn ""
                 warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-dep#build-configuration"
                 warn ""


### PR DESCRIPTION
`bin/compile` retrieves the list of Go packages to install from `metadata.heroku['install']` section of `Gopkg.toml`, however the default value warning message suggests that it should be set in
`metadata.heroku['pkg-spec']`. This PR changes this message to use `install` instead.