### PR TITLE
Fix gitCredHelper function for go module usage

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -238,7 +238,7 @@ setGitCredHelper() {
             if [ -f "${f}" ]; then
                 echo "Using credentials from GO_GIT_CRED__${protocol}__${host}" >&2
                 t=$(cat ${f})
-                if [ "${t}" =~ ":" ]; then
+                if [[ "${t}" =~ ":" ]]; then
                     username="$(echo $t | cut -d : -f 1)"
                     password="$(echo $t | cut -d : -f 2)"
                 else


### PR DESCRIPTION
Since the =~ is a bash extension, it requires double brackets
to be evaluated properly. Using only single brackets results in
a syntax error.

Could also be updated to use:

```bash
if printf "${t}" | grep -Eq ":" ; then
```

if POSIX compatibility is important. Without this update trying to 
build with go modules and private repositories fails:

> }; gitCredHelper get: 46: [: MY_GITHUB_TOKEN: unexpected operator