### PR TITLE
Run tests in CI when using go modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Add go1.10.8 and default to it when go1.10 is specified
 * Add go1.11.5 and default to it when go1.11 is specified or no version is specified.
+* Support go modules on Heroku CI (bin/test-compile & bin/test).
 
 ## v99 (2019-01-15)
 * Add go1.12beta1 and default to it when go1.12 is specified

--- a/bin/test
+++ b/bin/test
@@ -25,16 +25,30 @@ if [ -f "${build}/.heroku/go/.meta" ]; then
   source "${build}/.heroku/go/.meta"
 fi
 
-export GOPATH="${build}"
 export GOROOT="${build}/.heroku/go"
-PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+if [[ "$TOOL" = "gomodules" ]]; then
+  PATH="${build}/bin:${GOROOT}/bin:${PATH}"
+else
+  export GOPATH="${build}"
+  PATH="${GOPATH}/bin:${GOROOT}/bin:${PATH}"
+fi
 
 # Install our vendored copy of github.com/apg/patter
-GOPATH="${GOPATH}:${testpack}/lib" GOBIN="${build}/bin" go install github.com/apg/patter
+GOPATH="${testpack}/lib" GOBIN="${build}/bin" go install github.com/apg/patter
 
 output=$(mktemp)
 
 case "${TOOL}" in
+    gomodules)
+        cd "${build}"
+        step "Running Tests With: go test -race -v ./... | patter"
+        go test -race -v ./... 2>&1 | tee -a ${output} | patter
+        step
+        if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
+            step 'Running Benchmarks With: go test -run=_ -bench=. -benchmem -v ./...'
+            go test -run=_ -bench=. -benchmem -v ./... 2>&1
+        fi
+    ;;
     govendor)
         cd "${GOPATH}/src/${NAME}"
         step "Running Tests With: govendor test -race -v +local | patter"

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -1,7 +1,17 @@
 #!/bin/bash
 # usage: bin/test-compile <build-dir> <cache-dir> <env-dir>
 
+mkdir -p "${1}"
+build="$(cd ${1}/ && pwd)"
+
 testpack=$(cd "$(dirname $0)/.." && pwd)
 echo "true" > "${3}/GO_INSTALL_TOOLS_IN_IMAGE"
-echo "true" > "${3}/GO_SETUP_GOPATH_IN_IMAGE"
+
+if [[ -f "${build}/go.mod" ]]; then
+    #go modules, so no GOPATH
+    echo "false" > "${3}/GO_SETUP_GOPATH_IN_IMAGE"
+else
+    echo "true" > "${3}/GO_SETUP_GOPATH_IN_IMAGE"
+fi
+
 ${testpack}/bin/compile "${1}" "${2}" "${3}"


### PR DESCRIPTION
Instead of #281.

I've tested this with a sample repo and it works (tm).