### PR TITLE
Version support & metrics

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -445,6 +445,7 @@ fi
 
 export GOPATH
 
+mcount "pkgmanagement.$TOOL"
 # GB installation
 case "${TOOL}" in
     gomodules)

--- a/data.json
+++ b/data.json
@@ -1,6 +1,6 @@
 {
   "Go": {
-    "Supported": ["go1.11.5", "go1.12"],
+    "Supported": ["go1.12","go1.11.5","go1.11.4", "go1.11.3", "go1.11.2", "go1.11.1"],
     "DefaultVersion": "go1.11.5",
     "VersionExpansion": {
       "go1.12.0": "go1.12",
@@ -78,7 +78,12 @@
   "test": {
     "assets": [
       "jq-linux64",
+      "go1.12.linux-amd64.tar.gz",
       "go1.11.5.linux-amd64.tar.gz",
+      "go1.11.4.linux-amd64.tar.gz",
+      "go1.11.3.linux-amd64.tar.gz",
+      "go1.11.2.linux-amd64.tar.gz",
+      "go1.11.1.linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",


### PR DESCRIPTION
## Reasons for making these changes
The current buildpack warns with a huge warning even for releases that are from two months ago. We used to support the last two minor versions. We discussed and we would like to support the last two major versions similar to what golang does here https://golang.org/doc/devel/release.html#policy 

## Changes
Now supports two major versions since the last release as per golang
This change also eliminates the 'unsupported' warning for latest releases from like two months ago
Adds metrics to count dependency management systems