### PR TITLE
Add codeowners for code review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @heroku/languages
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
+* @sowjumn
+* @freeformz
+
+# keep @heroku/languages last so the team is the one automatically tagged in code reviews
 * @heroku/languages
 


### PR DESCRIPTION
This brings the go buildpack into line with the rest of the official buildpacks.

Though I believe we either need to add a few more people to the @heroku/languages team, or expand this file.
