### PR TITLE
Fix up gomodules testing a little bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Fix up Go modules testing to include mod=vendor or mod=readonly and set GOPATH to a temporary directory so downloaded deps' tests aren't executed.
 
 ## v103 (2019-03-07)
 * Removed warnings on command line

--- a/bin/test
+++ b/bin/test
@@ -27,6 +27,10 @@ fi
 
 export GOROOT="${build}/.heroku/go"
 if [[ "$TOOL" = "gomodules" ]]; then
+  # use a tempdir to ensure that anything downloaded by the go tool isn't in $HOME
+  # If GOPATH is under the default becomes $HOME/go. $HOME is == ${build}, so
+  # go test ./... or the later benchmark run will pick up the downloaded packages.
+  export GOPATH="$(mktemp -d)"
   PATH="${build}/bin:${GOROOT}/bin:${PATH}"
 else
   export GOPATH="${build}"
@@ -41,12 +45,22 @@ output=$(mktemp)
 case "${TOOL}" in
     gomodules)
         cd "${build}"
-        step "Running Tests With: go test -race -v ./... | patter"
-        go test -race -v ./... 2>&1 | tee -a ${output} | patter
+        _tflags=("-race" "-v")
+        if [[ -d "./vendor" ]]; then
+          _tflags+=("-mod=vendor")
+        else
+          _tflags+=("-mod=readonly")
+        fi
+        step "Running Tests With: go test ${_tflags[@]} ./... | patter"
+        go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter
         step
         if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
-            step 'Running Benchmarks With: go test -run=_ -bench=. -benchmem -v ./...'
-            go test -run=_ -bench=. -benchmem -v ./... 2>&1
+            _tflags=("${_tflags[@]:1}") # push -race off
+            _tflags+=("-run=_")
+            _tflags+=("-bench=.")
+            _tflags+=("-benchmem")
+            step "Running Benchmarks With: go test ${_tflags[@]} ./..."
+            go test ${_tflags[@]} ./... 2>&1
         fi
     ;;
     govendor)


### PR DESCRIPTION
If GOPATH is unset, the $HOME/go is the default. Which can cause
the benchmark run to also test any downloaded dependencies.

If `./vendor` exists add -mod=vendor to pin to the contents of vendor.

If not, then, as per the go docs, add -mod=readonly.