### PR TITLE
[Go Modules] Detect main packages and install those when no package spec is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 * Fixed flag handling, which has been broken since -mod=vendor was added (at least)
+* For Go modules, detect main packages in the repo and install them when there isn't a specified package spec.
+* Only list the contents of bin/ that were installed/modified by the buildpack, instead of everything in bin/
+* Small updates to the readme
 
 ## v105 (2019-03-18)
 * Add go1.12.1 & go1.11.6

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ GO_BUCKET_URL := file:///buildpack/test/assets
 sync:
 	ACCESS_KEY=$(ACCESS_KEY) SECRET_KEY=$(SECRET_KEY) ./bin/sync-files.sh
 
-test: BASH_COMMAND := test/run
+test: BASH_COMMAND := test/run.sh
 test: docker
 
 shell: docker
 
-quick: BASH_COMMAND := test/quick; bash
+quick: BASH_COMMAND := test/quick.sh; bash
 quick: docker
 
 # make FIXTURE=<fixture name> compile
-compile: BASH_COMMAND := test/quick compile $(FIXTURE); bash
+compile: BASH_COMMAND := test/quick.sh compile $(FIXTURE); bash
 compile: docker
 
 publish:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ article][app-engine-build-constraints] for more info.
 
 ## Go Module Specifics
 
+When using go modules, this buildpack will search the code base for `main`
+packages, ignoring any in `vendor/`, and will automatically compile those
+packages. If this isn't what you want you can specify specific package spec(s)
+via the `go.mod` file's `// +heroku install` directive (see below).
+
 The `go.mod` file allows for arbitrary comments. This buildpack utilizes [build
 constraint](https://golang.org/pkg/go/build/#hdr-Build_Constraints) style
 comments to track Heroku build specific configuration which is encoded in the
@@ -67,11 +72,14 @@ following way:
 
   Example: `// +heroku goVersion go1.11`
 
-- `// +heroku install <packagespec>[, <packagespec>]`: a space seperated list of
-  the packages you want to install. If not specified, this defaults to `.`.
-  Other common choices are: `./cmd/...` (all packages and sub packages in the
-  `cmd` directory) and `./...` (all packages and sub packages of the current
-  directory). The exact choice depends on the layout of your repository though.
+- `// +heroku install <packagespec>[ <packagespec>]`: a space seperated list of
+  the packages you want to install. If not specified, the buildpack defaults to
+  detecting the `main` packages in the code base. Generally speaking this should
+  be sufficient for most users. If this isn't what you want you can instruct the
+  buildpack to only build certain packages via this option. Other common choices
+  are: `./cmd/...` (all packages and sub packages in the `cmd` directory) and
+  `./...` (all packages and sub packages of the current directory). The exact
+  choice depends on the layout of your repository though.
 
   Example: `// +heroku install ./cmd/... ./special`
 

--- a/README.md
+++ b/README.md
@@ -303,21 +303,22 @@ that tests have been added to the `test/run` script and any corresponding fixtur
 
 ### Tests
 
-Requires docker.
+[Make] & [docker] are required to run tests.
 
 ```console
 make test
 ```
 
-### Compiling a fixture
+### Compiling a fixture locally
 
-Requires docker.
+[Make] & [docker] are required to compile a fixture.
 
 ```console
 make FIXTURE=<fixture name> compile
 ```
 
-You will then be dropped into a bash prompt in the container in which the fixture was compiled in.
+You will then be dropped into a bash prompt in the container that the fixture
+was compiled in.
 
 ## Using with cgo
 
@@ -358,9 +359,11 @@ into the compiled executable.
 
 ## Testpack
 
-This buildpack also supports the testpack API.
+This buildpack supports the testpack API.
 
 ## Deploying
+
+[Make] & the [Heroku Toolbelt][toolbelt] are required to deploy.
 
 ```console
 make publish # && follow the prompts
@@ -395,3 +398,6 @@ make publish # && follow the prompts
 [gomodules]: https://github.com/golang/go/wiki/Modules
 [DefaultVersion]: https://github.com/heroku/heroku-buildpack-go/blob/master/data.json#L4
 [Procfile]: https://devcenter.heroku.com/articles/procfile
+[make]: https://www.gnu.org/software/make/
+[docker]: https://www.docker.com/
+[toolbelt]: https://devcenter.heroku.com/articles/heroku-cli

--- a/bin/compile
+++ b/bin/compile
@@ -444,6 +444,7 @@ export GOPATH
 mcount "pkgmanagement.$TOOL"
 
 mainPackagesInModule() {
+  # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
   go list -find -mod=vendor -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
 }
 
@@ -461,7 +462,7 @@ case "${TOOL}" in
                 warn "Unsure what package(s) to install, defaulting to '.'"
                 warn ""
                 pkgs="default"
-                mcount "pkginstall.default"
+                mcount "pkginstall.detect-failed"
             else
                 info ""
                 info "Detected the following main packages to install:"
@@ -480,7 +481,7 @@ case "${TOOL}" in
         fi
 
         if [[ "${pkgs}" =~ "..." ]]; then
-            mcount "pkginstall.dot_dot_dot"
+            mcount "package_spec.contains.dot_dot_dot"
         fi
 
         warnPackageSpecOverride

--- a/bin/compile
+++ b/bin/compile
@@ -657,6 +657,6 @@ bin_path="${build}/bin"
 bin_files=`ls ${bin_path}`
 echo -e "\nCompiled the following binaries:"
 for fyle in $bin_files; do
-  info "$(echo ./bin/$fyle)"
+  info "./bin/$fyle"
 done 
 echo ""

--- a/bin/compile
+++ b/bin/compile
@@ -15,12 +15,12 @@ ensureInPath "jq-linux64" "${cache}/.jq/bin"
 # This is used by the buildpack stdlib for metrics
 BPLOG_PREFIX="buildpack.go"
 
-STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
+STDLIB_DIR=$(mktemp -d -t stdlib.XXXXX)
 
 ### Load dependencies
 
-curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh' > "$STDLIB_FILE"
-source "$STDLIB_FILE"
+ensureFile "stdlib.sh.v8" "${STDLIB_DIR}" "chmod a+x"
+source "${STDLIB_DIR}/stdlib.sh.v8"
 
 DefaultGoVersion="$(<${DataJSON} jq -r '.Go.DefaultVersion')"
 DepVersion="$(<${DataJSON} jq -r '.Dep.DefaultVersion')"

--- a/bin/compile
+++ b/bin/compile
@@ -443,6 +443,8 @@ mcount "pkgmanagement.$TOOL"
 
 case "${TOOL}" in
     gomodules)
+        cd ${build}
+        step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
         if [ -z "${pkgs}" ]; then
             if [ -d "${build}/cmd" ]; then
@@ -464,7 +466,6 @@ case "${TOOL}" in
         fi
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
-        cd ${build}
         export GOBIN="${build}/bin"
         if [[ -f bin/go-pre-compile ]]; then
             step "Running bin/go-pre-compile hook"

--- a/bin/compile
+++ b/bin/compile
@@ -10,6 +10,8 @@ env_dir="${3}"
 
 buildpack=$(cd "$(dirname $0)/.." && pwd)
 source "${buildpack}/lib/common.sh"
+snapshotBinBefore
+
 ensureInPath "jq-linux64" "${cache}/.jq/bin"
 
 # This is used by the buildpack stdlib for metrics
@@ -464,7 +466,7 @@ case "${TOOL}" in
                 info ""
                 info "Detected the following main packages to install:"
                 for pkg in ${pkgs}; do
-                    info "\t ${pkg}"
+                    info "\t\t${pkg}"
                 done
                 info ""
                 mcount "pkginstall.auto"
@@ -677,10 +679,10 @@ if [ "${TOOL}" != "gb" ]; then
     echo "NAME=${name}" >> "${t}"
 fi
 
-bin_path="${build}/bin"
-bin_files=`ls ${bin_path}`
-echo -e "\nCompiled the following binaries:"
-for fyle in $bin_files; do
-  info "./bin/$fyle"
-done 
-echo ""
+_newOrUpdatedBinFiles=$(binDiff)
+info ""
+info "Installed the following binaries:"
+for fyle in ${_newOrUpdatedBinFiles}; do
+  info "\t\t${fyle}"
+done
+info ""

--- a/bin/compile
+++ b/bin/compile
@@ -441,22 +441,46 @@ export GOPATH
 # GB installation
 mcount "pkgmanagement.$TOOL"
 
+mainPackagesInModule() {
+  go list -find -mod=vendor -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
+}
+
 case "${TOOL}" in
     gomodules)
         cd ${build}
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
         if [ -z "${pkgs}" ]; then
-            if [ -d "${build}/cmd" ]; then
-                # Supports standard Go directory structure  https://github.com/golang-standards/project-layout#go-directories
-                step "Detected \"cmd\" directory. Installing packages under \"cmd\""
-                mcount "pkginstall.cmd"
-                pkgs="./cmd/..."
-            else
-                mcount "pkginstall.default"
+            pkgs=$(mainPackagesInModule)
+            if [ -z "${pkgs}" ]; then
+                warn ""
+                warn "No main packages found in module ${name}"
+                warn ""
+                warn "Unsure what package(s) to install, defaulting to '.'"
+                warn ""
                 pkgs="default"
+                mcount "pkginstall.default"
+            else
+                info ""
+                info "Detected the following main packages to install:"
+                for pkg in ${pkgs}; do
+                    info "\t ${pkg}"
+                done
+                info ""
+                mcount "pkginstall.auto"
+            fi
+        else
+            if [ -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
+                mcount "pkginstall.go_install_package_spec"
+            else
+                mcount "pkginstall.heroku_install"
             fi
         fi
+
+        if [[ "${pkgs}" =~ "..." ]]; then
+            mcount "pkginstall.dot_dot_dot"
+        fi
+
         warnPackageSpecOverride
         handleDefaultPkgSpec
         massagePkgSpecForVendor

--- a/data.json
+++ b/data.json
@@ -117,6 +117,7 @@
   },
   "test": {
     "assets": [
+      "stdlib.sh.v8",
       "jq-linux64",
       "go1.11.6.linux-amd64.tar.gz",
       "go1.12.1.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -415,6 +415,10 @@
     "SHA": "cc4b544f982fb3cf0ac84fe9c78f3fc37513f31daba90f247e9d477f5daf2396",
     "URL": "https://github.com/golang-migrate/migrate/releases/download/v3.4.0/migrate.linux-amd64.tar.gz"
   },
+  "stdlib.sh.v8": {
+    "SHA": "48b1c663ceda9e93a42fa2ed610fbdd12f9801abd55c317990b30ec75dc3d715",
+    "URL": "https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh"
+  },
   "tq-v0.4-linux-amd64": {
     "LocalName": "tq",
     "SHA": "36d33a30e2cafe4b747b8de2449185a13239fb6da2887dde74f3d390fc639e3b",

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -278,11 +278,13 @@ setGoVersionFromEnvironment() {
 determineTool() {
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
-        info ""
-        step "Detected go modules - go.mod"
-        info ""
+        step ""
+        info "Detected go modules via go.mod"
+        step ""
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
-        name=$(awk '{ if ($1 == "module" ) { print $2; exit } }' ${goMOD} | cut -d/ -f3)
+        name=$(awk '{ if ($1 == "module" ) { print $2; exit } }' < ${goMOD})
+        info "Detected Module Name: ${name}"
+        step ""
         warnGoVersionOverride
         if [ -z "${ver}" ]; then
             ver=${DefaultGoVersion}

--- a/test/quick.sh
+++ b/test/quick.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-. $(pwd)/test/utils
+. $(pwd)/test/utils.sh
 
 export SHUNIT_TMPDIR=/tmp
 oneTimeSetUp

--- a/test/shunit2.sh
+++ b/test/shunit2.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /usr/bin/env bash
 # $Id: shunit2 335 2011-05-01 20:10:33Z kate.ward@forestent.com $
 # vim:et:ft=sh:sts=2:sw=2
 #


### PR DESCRIPTION
Closes #308 

This PR does a few things:
1. For go modules, detect *any* main packages in the repo, that are not in vendor, and when there isn't a specified package spec, install those packages.
1. Instead of listing all of bin/* as being what the buildpack has installed, take an shasum snapshot of the contents of bin/ (if it exists) before doing anything, and a snapshot at the end and detail what files the buildpack has installed.
1. Small set of related(ish) README updates.