### PR TITLE
 Handle quoted module names in go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Handle quoted module names in go.mod
 
 ## v107 (2019-04-02)
 * Handle non files in bin/ (symlinks, directories, etc) when diffing to determine contents of bin/

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -325,7 +325,7 @@ determineTool() {
         info "Detected go modules via go.mod"
         step ""
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
-        name=$(awk '{ if ($1 == "module" ) { print $2; exit } }' < ${goMOD})
+        name=$(awk '{ if ($1 == "module" ) { gsub(/"/, "", $2); print $2; exit } }' < ${goMOD})
         info "Detected Module Name: ${name}"
         step ""
         warnGoVersionOverride

--- a/test/fixtures/mod-with-quoted-module/go.mod
+++ b/test/fixtures/mod-with-quoted-module/go.mod
@@ -1,0 +1,3 @@
+module "github.com/heroku/fixture"
+
+go 1.12

--- a/test/fixtures/mod-with-quoted-module/main.go
+++ b/test/fixtures/mod-with-quoted-module/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("fixture")
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModWithQuotesModule() {
+  fixture "mod-with-quoted-module"
+
+  assertDetected
+
+  compile
+  assertModulesBoilerplateCaptured
+  assertGoInstallCaptured
+  assertGoInstallOnlyFixturePackageCaptured
+
+  assertCapturedSuccess
+  assertInstalledFixtureBinary
+  assertFile "web: fixture" "Procfile"
+}
+
 testModWithNonFilesInBin() {
   fixture "mod-with-non-files-in-bin"
 


### PR DESCRIPTION
Running `go mod tidy` will (at least with go1.12.1) remove them, but let's handle this case anyway.

closes #315 