### PR TITLE
Add go1.12.2 / go1.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add go1.11.7 and expand go1.11 to go.11.7.
 * Drop 'Go.SupportsModuleExperiment' from data.json, instead error for go versions < go1.11 when using modules.
 * Drop 'Go.Supported' from data.json since the buildpack is no longer using it for anything.
+* Skip vendored mattes migrate compile on cedar:14 due to gcc error.
 
 ## v107 (2019-04-02)
 * Handle non files in bin/ (symlinks, directories, etc) when diffing to determine contents of bin/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 * Handle quoted module names in go.mod
+* Add go1.12.2, expand go1.12 to go1.12.2, and default to go1.12.2
+* Add go1.11.7 and expand go1.11 to go.11.7.
+* Drop 'Go.SupportsModuleExperiment' from data.json, instead error for go versions < go1.11 when using modules.
+* Drop 'Go.Supported' from data.json since the buildpack is no longer using it for anything.
 
 ## v107 (2019-04-02)
 * Handle non files in bin/ (symlinks, directories, etc) when diffing to determine contents of bin/

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ shell: docker
 quick: BASH_COMMAND := test/quick.sh; bash
 quick: docker
 
-# make FIXTURE=<fixture name> compile
-compile: BASH_COMMAND := test/quick.sh compile $(FIXTURE); bash
+# make FIXTURE=<fixture name> ENV=<FOO=BAR> compile
+compile: BASH_COMMAND := test/quick.sh compile $(FIXTURE) $(ENV); bash
 compile: docker
 
 publish:

--- a/data.json
+++ b/data.json
@@ -1,15 +1,11 @@
 {
   "Go": {
-    "Supported": [
-      "go1.12.1",
-      "go1.11.6"
-    ],
-    "DefaultVersion": "go1.12.1",
+    "DefaultVersion": "go1.12.2",
     "VersionExpansion": {
       "go1.12.0": "go1.12",
-      "go1.12": "go1.12.1",
+      "go1.12": "go1.12.2",
       "go1.11.0": "go1.11",
-      "go1.11": "go1.11.6",
+      "go1.11": "go1.11.7",
       "go1.10.0": "go1.10",
       "go1.10": "go1.10.8",
       "go1.9.0": "go1.9",
@@ -69,23 +65,6 @@
       "go1.6.2",
       "go1.6.3",
       "go1.6.4"
-    ],
-    "SupportsModuleExperiment": [
-      "go1.11beta2",
-      "go1.11beta3",
-      "go1.11rc1",
-      "go1.11rc2",
-      "go1.11",
-      "go1.11.1",
-      "go1.11.2",
-      "go1.11.3",
-      "go1.11.4",
-      "go1.11.5",
-      "go1.12beta1",
-      "go1.12beta2",
-      "go1.12rc1",
-      "go1.12",
-      "go1.12.1"
     ]
   },
   "Dep": {
@@ -119,8 +98,8 @@
     "assets": [
       "stdlib.sh.v8",
       "jq-linux64",
-      "go1.11.6.linux-amd64.tar.gz",
-      "go1.12.1.linux-amd64.tar.gz",
+      "go1.11.7.linux-amd64.tar.gz",
+      "go1.12.2.linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -144,6 +144,10 @@
     "SHA": "4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49",
     "URL": "https://storage.googleapis.com/golang/go1.11.6.linux-amd64.tar.gz"
   },
+  "go1.11.7.linux-amd64.tar.gz": {
+    "SHA": "db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8",
+    "URL": "https://storage.googleapis.com/golang/go1.11.7.linux-amd64.tar.gz"
+  },
   "go1.11.linux-amd64.tar.gz": {
     "SHA": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
     "URL": "https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz"
@@ -167,6 +171,10 @@
   "go1.12.1.linux-amd64.tar.gz": {
     "SHA": "2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec",
     "URL": "https://storage.googleapis.com/golang/go1.12.1.linux-amd64.tar.gz"
+  },
+  "go1.12.2.linux-amd64.tar.gz": {
+    "SHA": "f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f",
+    "URL": "https://storage.googleapis.com/golang/go1.12.2.linux-amd64.tar.gz"
   },
   "go1.12.linux-amd64.tar.gz": {
     "SHA": "750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13",

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -318,6 +318,12 @@ setGoVersionFromEnvironment() {
     ver=${GOVERSION:-$DefaultGoVersion}
 }
 
+supportsGoModules() {
+    local version="${1}"
+    # Ex:      "go1.10.4" | ["go1","10", "4"] | ["1","10","4"]     | [1,10,4]      |  [1]           [10]      == exit 1 (fail)
+    echo "\"${version}\"" | jq -e 'split(".") | map(gsub("go";"")) | map(tonumber) | .[0] >= 1 and .[1] < 11' &> /dev/null
+}
+
 determineTool() {
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
@@ -338,7 +344,8 @@ determineTool() {
             warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
             warn ""
         fi
-        if ! echo "\"${ver}\"" | jq -e 'split(".") | map(gsub("go";"")) | map(tonumber) | .[0] >= 1 and .[1] >= 11' &> /dev/null; then
+
+        if supportsGoModules "${ver}"; then
             err "You are using ${ver}, which does not support Go modules"
             err ""
             err "Go modules are supported by go1.11 and above."

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -338,16 +338,16 @@ determineTool() {
             warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
             warn ""
         fi
-        if ! <"${DataJSON}" jq  -e '.Go.SupportsModuleExperiment | any(. == "'${ver}'")' &> /dev/null; then
+        if ! echo "\"${ver}\"" | jq -e 'split(".") | map(gsub("go";"")) | map(tonumber) | .[0] >= 1 and .[1] >= 11' &> /dev/null; then
             err "You are using ${ver}, which does not support Go modules"
             err ""
-            err "These go versions support Go modules: $(<${DataJSON} jq -c -r -M '.Go.SupportsModuleExperiment | sort | join(", ")')"
+            err "Go modules are supported by go1.11 and above."
             err ""
-            err "Please add a comment in your go.mod file, or update an existing one, to specify a Go version that does like so:"
-            err "// +heroku goVersion go1.11.5"
+            err "Please add/update the comment in your go.mod file to specify a Go version >= go1.11 like so:"
+            err "// +heroku goVersion ${DefaultGoVersion}"
             err ""
             err "Then commit and push again."
-           exit 1
+            exit 1
         fi
     elif [ -f "${depTOML}" ]; then
         TOOL="dep"

--- a/test/run.sh
+++ b/test/run.sh
@@ -628,6 +628,14 @@ testGovendorGo14WithGOVERSIONOverride() {
 }
 
 testGlideMassageVendor() {
+  if [ "${IMAGE}" = "heroku/cedar:14" ]; then
+    echo "!!!"
+    echo "!!! Skipping this test on heroku/cedar:14"
+    echo "!!! It fails with gcc errors when compiling mattes/migrate"
+    echo "!!!"
+    return 0
+  fi
+
   fixture "glide-massage-vendor"
 
   env "GO_INSTALL_PACKAGE_SPEC" ". github.com/mattes/migrate"

--- a/test/run.sh
+++ b/test/run.sh
@@ -101,7 +101,7 @@ testModOldVersion() {
   compile
   assertCaptured "Detected go modules via go.mod"
   assertCaptured "Detected Module Name: github.com/heroku/fixture"
-  assertCapturedError 1 "Please add a comment in your go.mod file, or update an existing one, to specify a Go version that does like so"
+  assertCapturedError 1 "Please add/update the comment in your go.mod file to specify a Go version >= go1.11 like so:"
 }
 
 testDepWithGolangMigrate() {


### PR DESCRIPTION
Drop support for `Go.SupportsModuleExperiment`. It's not really
and expermiment anymore and any version of go >= go1.11 will be
supporting it.

Drop support for `Go.Supported` since the buildpack isn't using it
anymore. :-(