### PR TITLE
Go1.12.3 / 1.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add go1.12.3, expand go1.12 to go1.12.3, and default to go1.12.3
+* Add go1.11.8 and expand go1.11 to go.11.8.
 
 ## v108 (2019-04-08)
 * Handle quoted module names in go.mod

--- a/bin/sync-files.sh
+++ b/bin/sync-files.sh
@@ -29,7 +29,6 @@ cd "${td}"
 echo "Getting bucket credentials"
 
 S3CMD="s3cmd $(lpass show --sync=now --notes 9022891142845286058 | jq -r '.AccessKey | "--access_key=\(.AccessKeyId) --secret_key=\(.SecretAccessKey)"')"
-echo $S3CMD
 
 echo "Syncing contents of ${BUCKET} to $(pwd)."
 ${S3CMD} sync --check-md5 ${BUCKET} ./

--- a/data.json
+++ b/data.json
@@ -1,11 +1,11 @@
 {
   "Go": {
-    "DefaultVersion": "go1.12.2",
+    "DefaultVersion": "go1.12.3",
     "VersionExpansion": {
       "go1.12.0": "go1.12",
-      "go1.12": "go1.12.2",
+      "go1.12": "go1.12.3",
       "go1.11.0": "go1.11",
-      "go1.11": "go1.11.7",
+      "go1.11": "go1.11.8",
       "go1.10.0": "go1.10",
       "go1.10": "go1.10.8",
       "go1.9.0": "go1.9",
@@ -98,8 +98,8 @@
     "assets": [
       "stdlib.sh.v8",
       "jq-linux64",
-      "go1.11.7.linux-amd64.tar.gz",
-      "go1.12.2.linux-amd64.tar.gz",
+      "go1.11.8.linux-amd64.tar.gz",
+      "go1.12.3.linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -148,6 +148,10 @@
     "SHA": "db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8",
     "URL": "https://storage.googleapis.com/golang/go1.11.7.linux-amd64.tar.gz"
   },
+  "go1.11.8.linux-amd64.tar.gz": {
+    "SHA": "e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1",
+    "URL": "https://storage.googleapis.com/golang/go1.11.8.linux-amd64.tar.gz"
+  },
   "go1.11.linux-amd64.tar.gz": {
     "SHA": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
     "URL": "https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz"
@@ -175,6 +179,10 @@
   "go1.12.2.linux-amd64.tar.gz": {
     "SHA": "f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f",
     "URL": "https://storage.googleapis.com/golang/go1.12.2.linux-amd64.tar.gz"
+  },
+  "go1.12.3.linux-amd64.tar.gz": {
+    "SHA": "3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df",
+    "URL": "https://storage.googleapis.com/golang/go1.12.3.linux-amd64.tar.gz"
   },
   "go1.12.linux-amd64.tar.gz": {
     "SHA": "750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13",


### PR DESCRIPTION
go1.12.3 (released 2019/04/08) fixes an issue where using the prebuilt
binary releases on older versions of GNU/Linux led to failures when
linking programs that used cgo. Only Linux users who hit this issue need
to update.

go1.11.8 (released 2019/04/08) fixes an issue where using the prebuilt
binary releases on older versions of GNU/Linux led to failures when
linking programs that used cgo. Only Linux users who hit this issue need
to update.