### PR TITLE
Set GOPATH so downloaded modules are cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Set GOPATH when using Go modules to capture downloaded dependencies.
 
 ## v110 (2019-04-15)
 * Add go1.12.4, expand go1.12 to go1.12.4, and default to go1.12.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+
+## v111 (2019-04-18)
 * Set GOPATH when using Go modules to capture downloaded dependencies.
 
 ## v110 (2019-04-15)

--- a/bin/compile
+++ b/bin/compile
@@ -494,6 +494,7 @@ case "${TOOL}" in
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
         export GOBIN="${build}/bin"
+        export GOPATH="${cache}/go-path"
         if [[ -f bin/go-pre-compile ]]; then
             step "Running bin/go-pre-compile hook"
             chmod a+x bin/go-pre-compile

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,44 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModDepsRecompile() {
+  fixture "mod-deps"
+
+  assertDetected
+
+  compile
+  assertModulesBoilerplateCaptured
+  assertGoInstallCaptured
+  assertGoInstallOnlyFixturePackageCaptured
+
+  # The other deps are downloaded/installed
+  assertCaptured "
+go: finding github.com/gorilla/mux v1.6.2
+go: finding github.com/gorilla/context v1.1.1
+go: downloading github.com/gorilla/mux v1.6.2
+go: extracting github.com/gorilla/mux v1.6.2
+github.com/gorilla/mux
+"
+  assertCapturedSuccess
+  assertInstalledFixtureBinary
+
+  # Second compile
+  compile
+  assertModulesBoilerplateCaptured
+  assertGoInstallOnlyFixturePackageCaptured
+
+  # On the second compile go should already be fetched and installed & the packages should be downloaded already.
+  assertNotCaptured "Fetching ${DEFAULT_GO_VERSION}.linux-amd64.tar.gz... done"
+  assertNotCaptured "Installing ${DEFAULT_GO_VERSION}"
+  assertNotCaptured "go: finding github.com/gorilla/mux v1.6.2"
+  assertNotCaptured "go: finding github.com/gorilla/context v1.1.1"
+  assertNotCaptured "go: downloading github.com/gorilla/mux v1.6.2"
+  assertNotCaptured "go: extracting github.com/gorilla/mux v1.6.2"
+
+  assertCapturedSuccess
+  assertInstalledFixtureBinary
+}
+
 testModWithQuotesModule() {
   fixture "mod-with-quoted-module"
 


### PR DESCRIPTION
Without this downloaded modules are re-downloaded on next push, even when the version doesn't change.

Fixes #276 