### PR TITLE
Setup Procfile for apps using Go Modules when no Procfile exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* *GoModules* When no Procfile exists and only a single main package exists, setup the resulting executable as the web process type.
+* *GoModules* When no Procfile exists and multiple main packages exist, setup the resulting executables as process types of the same name.
+* *GoModules* This means that a main package in a `web` directory will be setup as the web process type, a package in a `worker` directory will be setup as the worker process type, etc.
 
 ## v111 (2019-04-18)
-* Set GOPATH when using Go modules to capture downloaded dependencies.
+* *GoModules* Set GOPATH to capture downloaded dependencies.
 
 ## v110 (2019-04-15)
 * Add go1.12.4, expand go1.12 to go1.12.4, and default to go1.12.4
@@ -15,10 +18,10 @@
 * Add go1.11.8 and expand go1.11 to go.11.8.
 
 ## v108 (2019-04-08)
-* Handle quoted module names in go.mod
+* *GoModules* Handle quoted module names in go.mod
 * Add go1.12.2, expand go1.12 to go1.12.2, and default to go1.12.2
 * Add go1.11.7 and expand go1.11 to go.11.7.
-* Drop 'Go.SupportsModuleExperiment' from data.json, instead error for go versions < go1.11 when using modules.
+* *GoModules* Drop 'Go.SupportsModuleExperiment' from data.json, instead error for go versions < go1.11 when using modules.
 * Drop 'Go.Supported' from data.json since the buildpack is no longer using it for anything.
 * Skip vendored mattes migrate compile on cedar:14 due to gcc error.
 
@@ -26,8 +29,8 @@
 * Handle non files in bin/ (symlinks, directories, etc) when diffing to determine contents of bin/
 
 ## v106 (2019-04-01)
-* Fixed flag handling, which has been broken since -mod=vendor was added (at least)
-* For Go modules, detect main packages in the repo and install them when there isn't a specified package spec.
+* *GoModules* Fixed flag handling, which has been broken since -mod=vendor was added (at least)
+* *GoModules* Detect main packages in the repo and install them when there isn't a specified package spec.
 * Only list the contents of bin/ that were installed/modified by the buildpack, instead of everything in bin/
 * Small updates to the readme
 
@@ -37,7 +40,7 @@
 * If ./cmd exists and no package spec is set, then set package spec to ./cmd/...
 
 ## v104 (2019-03-11)
-* Fix up Go modules testing to include mod=vendor or mod=readonly and set GOPATH to a temporary directory so downloaded deps' tests aren't executed.
+* *GoModules* Fix up Go modules testing to include mod=vendor or mod=readonly and set GOPATH to a temporary directory so downloaded deps' tests aren't executed.
 * Move publish script to /sbin/publish / don't push to master since it's disabled.
 * Add Codeowners to automate PR reviews.
 
@@ -56,7 +59,7 @@
 ## v100 (2019-02-12)
 * Add go1.10.8 and default to it when go1.10 is specified
 * Add go1.11.5 and default to it when go1.11 is specified or no version is specified.
-* Support go modules on Heroku CI (bin/test-compile & bin/test).
+* *GoModules* Support go modules on Heroku CI (bin/test-compile & bin/test).
 * Add pre/post compile run hooks: /bin/go-pre-compile & /bin/go-post-compile
 * Add go1.12rc1 and default to it when go1.12 is specified.
 

--- a/bin/compile
+++ b/bin/compile
@@ -448,6 +448,40 @@ mainPackagesInModule() {
   go list -find -mod=vendor -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
 }
 
+setupProcfile() {
+    if [ -f "${build}/Procfile" ]; then
+        return
+    fi
+    local pkgs=$(mainPackagesInModule)
+    if [ -z "${pkgs}" ]; then
+        return
+    fi
+    local pf=()
+    for pkg in ${pkgs}; do
+        local bn=$(basename ${pkg})
+        pf+=("${bn}: bin/${bn}")
+    done
+    if [ ${#pf} -eq 0 ]; then
+        return
+    fi
+    info ""
+    info "Created a Procfile with the following entries:"
+    if [ ${#pf[@]} -eq 1 ]; then
+        local line="web: bin/$(echo ${pf[0]} | cut -d / -f 2)"
+        echo "${line}" > ${build}/Procfile
+        info "\t\t${line}"
+    elif [ ${#pf[@]} -gt 1 ]; then
+        for pfl in "${pf[@]}"; do
+            echo "${pfl}" >> ${build}/Procfile
+            info "\t\t${pfl}"
+        done
+    fi
+    info ""
+    info "If these entries look incomplete or incorrect please create a Procfile with the required entries."
+    info "See https://devcenter.heroku.com/articles/procfile for more details about Procfiles"
+    info ""
+}
+
 case "${TOOL}" in
     gomodules)
         cd ${build}
@@ -636,8 +670,19 @@ esac
 installGolangMigrateIfWanted
 installMattesMigrateIfWanted
 
+_newOrUpdatedBinFiles=$(binDiff)
+info ""
+info "Installed the following binaries:"
+for fyle in ${_newOrUpdatedBinFiles}; do
+  info "\t\t${fyle}"
+done
+
 if [ -n "${src}" -a "${src}" != "${build}" -a -e "${src}/Procfile" ]; then
     mv -t "${build}" "${src}/Procfile"
+fi
+
+if [ "${TOOL}" == "gomodules" ]; then
+    setupProcfile
 fi
 
 if [ ! -e $build/Procfile -a -n "${name}" ]; then
@@ -681,10 +726,3 @@ if [ "${TOOL}" != "gb" ]; then
     echo "NAME=${name}" >> "${t}"
 fi
 
-_newOrUpdatedBinFiles=$(binDiff)
-info ""
-info "Installed the following binaries:"
-for fyle in ${_newOrUpdatedBinFiles}; do
-  info "\t\t${fyle}"
-done
-info ""

--- a/test/fixtures/mod-cmd-web/cmd/other/main.go
+++ b/test/fixtures/mod-cmd-web/cmd/other/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("other")
+}

--- a/test/fixtures/mod-cmd-web/cmd/web/main.go
+++ b/test/fixtures/mod-cmd-web/cmd/web/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("web")
+}

--- a/test/fixtures/mod-cmd-web/go.mod
+++ b/test/fixtures/mod-cmd-web/go.mod
@@ -1,0 +1,3 @@
+module github.com/heroku/fixture
+
+go 1.12

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModProcfileCreation() {
+  fixture "mod-cmd-web"
+
+  assertDetected
+  
+  compile
+  assertModulesBoilerplateCaptured
+  assertGoInstallCaptured
+  assertCaptured "Running: go install -v -tags heroku github.com/heroku/fixture/cmd/web
+github.com/heroku/fixture/cmd/other"
+
+  assertCapturedSuccess
+  assertFile "other: bin/other
+web: bin/web" "Procfile"
+}
 testModDepsRecompile() {
   fixture "mod-deps"
 
@@ -51,7 +66,7 @@ testModWithQuotesModule() {
 
   assertCapturedSuccess
   assertInstalledFixtureBinary
-  assertFile "web: fixture" "Procfile"
+  assertFile "web: bin/fixture" "Procfile"
 }
 
 testModWithNonFilesInBin() {
@@ -91,6 +106,9 @@ github.com/heroku/fixture/cmd/other"
   assertCaptured "Installed the following binaries:
 ./bin/fixture
 ./bin/other"
+
+  assertFile "fixture: bin/fixture
+other: bin/other" "Procfile"
   
   assertCapturedSuccess
   assertInstalledFixtureBinary
@@ -211,7 +229,7 @@ testModBasicWithoutProcfile() {
 
   assertCapturedSuccess
   assertInstalledFixtureBinary
-  assertFile "web: fixture" "Procfile"
+  assertFile "web: bin/fixture" "Procfile"
 }
 
 testModDeps() {
@@ -1141,7 +1159,7 @@ testGodepCreateProcfile() {
   assertCaptured "Installing go"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFile "web: fixture" "Procfile"
+  assertFile "web: bin/fixture" "Procfile"
 }
 
 testGovendorBasic() {
@@ -1207,7 +1225,7 @@ testGovendorCreateProcfile() {
   assertCaptured "Installing go"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFile "web: fixture" "Procfile"
+  assertFile "web: bin/fixture" "Procfile"
 }
 
 testGodepOldWorkspace() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -1159,7 +1159,7 @@ testGodepCreateProcfile() {
   assertCaptured "Installing go"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFile "web: bin/fixture" "Procfile"
+  assertFile "web: fixture" "Procfile"
 }
 
 testGovendorBasic() {
@@ -1225,7 +1225,7 @@ testGovendorCreateProcfile() {
   assertCaptured "Installing go"
   assertCapturedSuccess
   assertCompiledBinaryExists
-  assertFile "web: bin/fixture" "Procfile"
+  assertFile "web: fixture" "Procfile"
 }
 
 testGodepOldWorkspace() {


### PR DESCRIPTION
When no Procfile exists and

* only a single main package exists, setup the resulting executable as
  the web process type. This maintains existing behavior.

* multiple main packages exist, setup the resulting executables as
  process types of the same name. This means that a main package in a
  `web` directory will be setup as the web process type, a main package
  in a `worker` directory will be setup as the worker process type, etc.

This should make it very simple to push a go app and have Heroku
generally DTRT wrt process types.

This PR also tells the user what Procfile was generated and tells them
to create a Procfile if the generated one doesn't suit their needs.