### PR TITLE
Make files in the $cache/go-path readable if they aren't.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -277,7 +277,12 @@ ensureGo() {
     if [ -d "${goPath}" ]; then
         step "Using ${goVersion}"
     else
-        rm -rf ${cache}/* #For a go version change, we delete everything
+        #For a go version change, we delete everything
+        step "New Go Version, clearing old cache"
+        if [ -d "${cache}/go-path" ]; then
+            find "${cache}/go-path" ! -perm -u=w -print0 | xargs -0 chmod u+w 2>&1
+        fi
+        rm -rf ${cache}/*
         case "${goVersion}" in
             devel*)
                 local bGoVersion="$(expandVer ${DefaultGoVersion})"


### PR DESCRIPTION
Go modules writes a bunch of stuff in $GOPATH/pkg/mod as read-only.
Standard rm -rf throws an error when it encounters read-only files.
So find the files that are read-only and make them not read-only.

See also: https://github.com/golang/go/issues/27161