### PR TITLE
Make it so compile doesn't need to know the location of the stdlib

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ source "${buildpack}/lib/common.sh"
 source "${buildpack}/lib/common_tools.sh"
 
 BPLOG_PREFIX="buildpack.go"
-source "${STDLIB_DIR}/stdlib.sh.v8"
+source "stdlib.sh.v8" # uses a path lookup. see common_tools.sh
 
 snapshotBinBefore
 

--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,6 @@ source "${buildpack}/lib/common.sh"
 source "${buildpack}/lib/common_tools.sh"
 
 BPLOG_PREFIX="buildpack.go"
-STDLIB_DIR="${TMPDIR:-"/tmp"}/go-buildpack-stdlib"
 source "${STDLIB_DIR}/stdlib.sh.v8"
 
 snapshotBinBefore

--- a/lib/common_tools.sh
+++ b/lib/common_tools.sh
@@ -4,5 +4,9 @@
 ensureInPath "jq-linux64" "${cache}/.jq/bin"
 
 # Ensure we have a copy of the stdlib
-STDLIB_DIR="${TMPDIR:-"/tmp"}/go-buildpack-stdlib"
+if [ -z "${TMPDIR}" ]; then
+  STDLIB_DIR=$(mktemp -d -t stdlib.XXXXX)
+else
+  STDLIB_DIR="${TMPDIR}/go-buildpack-stdlib"
+fi
 ensureFile "stdlib.sh.v8" "${STDLIB_DIR}" "chmod a+x"

--- a/lib/common_tools.sh
+++ b/lib/common_tools.sh
@@ -3,10 +3,5 @@
 # Ensure jq is installed.
 ensureInPath "jq-linux64" "${cache}/.jq/bin"
 
-# Ensure we have a copy of the stdlib
-if [ -z "${TMPDIR}" ]; then
-  STDLIB_DIR=$(mktemp -d -t stdlib.XXXXX)
-else
-  STDLIB_DIR="${TMPDIR}/go-buildpack-stdlib"
-fi
-ensureFile "stdlib.sh.v8" "${STDLIB_DIR}" "chmod a+x"
+# Ensure we have a copy of stdlib.sh.v8 in the path
+ensureInPath "stdlib.sh.v8" "$(mktemp -d -t go-buildpack-stdlib.XXXXX)" "chmod a+x"


### PR DESCRIPTION
This is so that multiple runs with different users (which is the use case for certain internal tools)

Includes #333, which I can't update because it comes via a fork.
Closes #333