### PR TITLE
Bump dep to v0.5.2. Include versions v0.5.{0,1}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* *Dep* Dep bumped to v0.5.2. Dep v0.5.1 & v0.5.0 also made available.
 
 ## v114 (2019-05-07)
 * *GoModules* Make read-only module files writable so they can be deleted during cache cleaning on Go version upgrade.

--- a/data.json
+++ b/data.json
@@ -68,7 +68,7 @@
     ]
   },
   "Dep": {
-    "DefaultVersion": "v0.4.1"
+    "DefaultVersion": "v0.5.2"
   },
   "Glide": {
     "DefaultVersion": "v0.12.3"
@@ -96,7 +96,7 @@
   },
   "test": {
     "assets": [
-      "dep-v0.4.1-linux-amd64",
+      "dep-v0.5.2-linux-amd64",
       "errors-0.8.0.tar.gz",
       "gb-0.4.4.tar.gz",
       "glide-v0.12.3-linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -20,6 +20,21 @@
     "SHA": "31144e465e52ffbc0035248a10ddea61a09bf28b00784fd3fdd9882c8cbb2315",
     "URL": "https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64"
   },
+  "dep-v0.5.0-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "287b08291e14f1fae8ba44374b26a2b12eb941af3497ed0ca649253e21ba2f83",
+    "URL": "https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64"
+  },
+  "dep-v0.5.1-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "7479cca72da0596bb3c23094d363ea32b7336daa5473fa785a2099be28ecd0e3",
+    "URL": "https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64"
+  },
+  "dep-v0.5.2-linux-amd64": {
+    "LocalName": "dep",
+    "SHA": "d2d7e7a620b7cca79a7d6884813acea4e848ffe01b4a1d59ddf135fe0eb17f1b",
+    "URL": "https://github.com/golang/dep/releases/download/0.5.2/dep-linux-amd64"
+  },
   "errors-0.8.0.tar.gz": {
     "SHA": "bacf6c58e490911398cee61742ddc6a90c560733e4c9dcb3d867b17a894c9dd5",
     "URL": "https://github.com/pkg/errors/archive/v0.8.0.tar.gz"


### PR DESCRIPTION
Dep v0.5.2 Fixes some bugs

Dep v0.5.0 added a bunch of things that people are using locally.