### PR TITLE
Tell xargs to not run if the input is empty.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -277,7 +277,7 @@ ensureGo() {
         #For a go version change, we delete everything
         step "New Go Version, clearing old cache"
         if [ -d "${cache}/go-path" ]; then
-            find "${cache}/go-path" ! -perm -u=w -print0 | xargs -0 chmod u+w 2>&1
+            find "${cache}/go-path" ! -perm -u=w -print0 | xargs -r -0 chmod u+w 2>&1
         fi
         rm -rf ${cache}/*
         case "${goVersion}" in


### PR DESCRIPTION
The GNU version of xargs runs the utility argument at least once, even if xargs input is empty. -r tells it not to. :-(