### PR TITLE
fix: Install bazaar for apps using go.mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Download and install bzr when modules are in use.
 
 ## v126 (2019-07-10)
 * Set the public bit on files uploaded by ./sbin/sync-files.sh so that the files are publicly available.

--- a/bin/compile
+++ b/bin/compile
@@ -147,24 +147,21 @@ ensureHG() {
 
 ensureBZR() {
     local bzrv="${1}"
-    local bzrvs=$(echo ${bzrv} | cut -d . -f 1,2)
-    local tbzrp=$(mktemp -d)
+    local tmp="$(mktemp -d)"
     local bzrp="${cache}/bzr/${bzrv}"
-    if test -d "${bzrp}"
-    then
+    if [ -x "${bzrp}/bin/bzr" ]; then
         step "Using bzr v${bzrv}"
     else
         rm -rf "${cache}/bzr"
         mkdir -p "${bzrp}"
-        start "Installing bzr ${bzrv}"
-        $CURL "https://launchpad.net/bzr/${bzrvs}/${bzrv}/+download/bzr-${bzrv}.tar.gz" | tar -zxf - --strip-components=1 -C ${tbzrp}
-        pushd "${tbzrp}" &> /dev/null
-        python setup.py install --force --home=${bzrp} &> /dev/null
+        step "Installing bzr ${bzrv}"
+        ensureFile "bzr-${bzrv}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
+        pushd "${tmp}" &> /dev/null
+            python setup.py install --force --home="${bzrp}" &> /dev/null
         popd &> /dev/null
-        finished
     fi
 
-    PATH="${bzrp}/bin:${PATH}"
+    addToPATH "${bzrp}/bin"
     export PYTHONPATH="${bzrp}/lib/python:${PYTHONPATH}"
 }
 

--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,7 @@ GovendorVersion="$(<${DataJSON} jq -r '.Govendor.DefaultVersion')"
 GBVersion="$(<${DataJSON} jq -r '.GB.DefaultVersion')"
 PkgErrorsVersion="$(<${DataJSON} jq -r '.PkgErrors.DefaultVersion')"
 MercurialVersion="$(<${DataJSON} jq -r '.HG.DefaultVersion')"
+BazaarVersion="$(<${DataJSON} jq -r '.BZR.DefaultVersion')"
 MattesMigrateVersion="$(<${DataJSON} jq -r '.MattesMigrate.DefaultVersion')"
 GolangMigrateVersion="$(<${DataJSON} jq -r '.GolangMigrate.DefaultVersion')"
 TQVersion="$(<${DataJSON} jq -r '.tq.DefaultVersion')"
@@ -142,6 +143,29 @@ ensureHG() {
     fi
 
     addToPATH "${hgPath}/bin"
+}
+
+ensureBZR() {
+    local bzrv="${1}"
+    local bzrvs=$(echo ${bzrv} | cut -d . -f 1,2)
+    local tbzrp=$(mktemp -d)
+    local bzrp="${cache}/bzr/${bzrv}"
+    if test -d "${bzrp}"
+    then
+        step "Using bzr v${bzrv}"
+    else
+        rm -rf "${cache}/bzr"
+        mkdir -p "${bzrp}"
+        start "Installing bzr ${bzrv}"
+        $CURL "https://launchpad.net/bzr/${bzrvs}/${bzrv}/+download/bzr-${bzrv}.tar.gz" | tar -zxf - --strip-components=1 -C ${tbzrp}
+        pushd "${tbzrp}" &> /dev/null
+        python setup.py install --force --home=${bzrp} &> /dev/null
+        popd &> /dev/null
+        finished
+    fi
+
+    PATH="${bzrp}/bin:${PATH}"
+    export PYTHONPATH="${bzrp}/lib/python:${PYTHONPATH}"
 }
 
 ensureGlide() {
@@ -480,6 +504,9 @@ setupProcfile() {
 
 case "${TOOL}" in
     gomodules)
+        ensureBZR "${BazaarVersion}"
+        ensureHG "${MercurialVersion}"
+
         cd ${build}
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}

--- a/data.json
+++ b/data.json
@@ -101,6 +101,7 @@
   },
   "test": {
     "assets": [
+      "bzr-2.7.0.tar.gz",
       "dep-v0.5.2-linux-amd64",
       "errors-0.8.0.tar.gz",
       "gb-0.4.4.tar.gz",

--- a/data.json
+++ b/data.json
@@ -87,6 +87,9 @@
   "HG": {
     "DefaultVersion": "3.9"
   },
+  "BZR": {
+    "DefaultVersion": "2.7.0"
+  },
   "MattesMigrate": {
     "DefaultVersion": "v3.0.0"
   },

--- a/files.json
+++ b/files.json
@@ -1,4 +1,8 @@
 {
+  "bzr-2.7.0.tar.gz": {
+    "SHA": "0d451227b705a0dd21d8408353fe7e44d3a5069e6c4c26e5f146f1314b8fdab3",
+    "URL": "https://launchpad.net/bzr/2.7/2.7.0/+download/bzr-2.7.0.tar.gz"
+  },
   "dep-linux-amd64": {
     "Comment": "This is here for backwards compat. Remove after a while.",
     "LocalName": "dep",

--- a/test/fixtures/mod-with-bzr-dep/go.mod
+++ b/test/fixtures/mod-with-bzr-dep/go.mod
@@ -1,0 +1,8 @@
+module github.com/heroku/fixture
+
+go 1.12
+
+require (
+	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect
+	launchpad.net/xmlpath v0.0.0-20130614043138-000000000004
+)

--- a/test/fixtures/mod-with-bzr-dep/go.sum
+++ b/test/fixtures/mod-with-bzr-dep/go.sum
@@ -1,0 +1,4 @@
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
+launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
+launchpad.net/xmlpath v0.0.0-20130614043138-000000000004 h1:B8nNZBUrx8YufDCAJjvO/lVs4GxXMQHyrjwJdJzXMFg=
+launchpad.net/xmlpath v0.0.0-20130614043138-000000000004/go.mod h1:vqyExLOM3qBx7mvYRkoxjSCF945s0mbe7YynlKYXtsA=

--- a/test/fixtures/mod-with-bzr-dep/main.go
+++ b/test/fixtures/mod-with-bzr-dep/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"launchpad.net/xmlpath"
+)
+
+func main() {
+	fmt.Println(xmlpath.Path{})
+	fmt.Println("fixture")
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # See README.md for info on running these tests.
 
+testModWithBZRDep() {
+  fixture "mod-with-bzr-dep"
+
+  assertDetected
+
+  compile
+  assertModulesBoilerplateCaptured
+  assertGoInstallCaptured
+  assertGoInstallOnlyFixturePackageCaptured
+
+  assertCapturedSuccess
+  assertInstalledFixtureBinary
+  assertFile "web: bin/fixture" "Procfile"
+}
+
 testTestPackModulesVendoredGolangLintCI() {
   fixture "mod-deps-vendored-with-tests"
 
@@ -47,6 +62,7 @@ github.com/heroku/fixture/cmd/other"
   assertFile "other: bin/other
 web: bin/web" "Procfile"
 }
+
 testModDepsRecompile() {
   fixture "mod-deps"
 


### PR DESCRIPTION
- fixes #344

`make testpack` fails leaving me in a shell inside Docker with an error saying "/buildpack/bin/test: line 46: go: command not found" so not sure how to test my changes.