### PR TITLE
go1.12.7 / go1.11.12 / Small update to sync-files.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+
+## v120 (2019-07-09)
 * Add go1.12.7, expand go1.12 to go1.12.7, and default to go1.12.7
 * Add go1.11.12 and expand go1.11 to go 1.11.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add go1.12.7, expand go1.12 to go1.12.7, and default to go1.12.7
+* Add go1.11.12 and expand go1.11 to go 1.11.12
 
 ## v119 (2019-06-27)
 * Add go1.13beta1 and make it the default when go1.13 is specified

--- a/data.json
+++ b/data.json
@@ -1,13 +1,13 @@
 {
   "Go": {
-    "DefaultVersion": "go1.12.6",
+    "DefaultVersion": "go1.12.7",
     "VersionExpansion": {
       "go1.13": "go1.13beta1",
       "go1.13.0": "go1.13beta1",
       "go1.12.0": "go1.12",
-      "go1.12": "go1.12.6",
+      "go1.12": "go1.12.7",
       "go1.11.0": "go1.11",
-      "go1.11": "go1.11.11",
+      "go1.11": "go1.11.12",
       "go1.10.0": "go1.10",
       "go1.10": "go1.10.8",
       "go1.9.0": "go1.9",
@@ -103,8 +103,8 @@
       "gb-0.4.4.tar.gz",
       "glide-v0.12.3-linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
-      "go1.11.11.linux-amd64.tar.gz",
-      "go1.12.6.linux-amd64.tar.gz",
+      "go1.11.12.linux-amd64.tar.gz",
+      "go1.12.7.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -179,6 +179,10 @@
     "SHA": "2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775",
     "URL": "https://storage.googleapis.com/golang/go1.11.11.linux-amd64.tar.gz"
   },
+  "go1.11.12.linux-amd64.tar.gz": {
+    "SHA": "14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d",
+    "URL": "https://storage.googleapis.com/golang/go1.11.12.linux-amd64.tar.gz"
+  },
   "go1.11.linux-amd64.tar.gz": {
     "SHA": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
     "URL": "https://storage.googleapis.com/golang/go1.11.linux-amd64.tar.gz"
@@ -222,6 +226,10 @@
   "go1.12.6.linux-amd64.tar.gz": {
     "SHA": "dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c",
     "URL": "https://storage.googleapis.com/golang/go1.12.6.linux-amd64.tar.gz"
+  },
+  "go1.12.7.linux-amd64.tar.gz": {
+    "SHA": "66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9",
+    "URL": "https://storage.googleapis.com/golang/go1.12.7.linux-amd64.tar.gz"
   },
   "go1.12.linux-amd64.tar.gz": {
     "SHA": "750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13",

--- a/sbin/aws.sh
+++ b/sbin/aws.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# source this file
+export AWS_ACCESS_KEY_ID="$(lpass show --sync=now --notes 9022891142845286058 | jq -r '.AccessKey | .AccessKeyId')"
+export AWS_SECRET_ACCESS_KEY="$(lpass show --sync=now --notes 9022891142845286058 | jq -r '.AccessKey | .SecretAccessKey')"

--- a/sbin/sync-files.sh
+++ b/sbin/sync-files.sh
@@ -29,9 +29,7 @@ mkdir -p "${cache}"
 cd "${cache}"
 
 echo "Getting bucket credentials"
-
-export AWS_ACCESS_KEY_ID="$(lpass show --sync=now --notes 9022891142845286058 | jq -r '.AccessKey | .AccessKeyId')"
-export AWS_SECRET_ACCESS_KEY="$(lpass show --sync=now --notes 9022891142845286058 | jq -r '.AccessKey | .SecretAccessKey')"
+source "${cwd}/sbin/aws.sh"
 
 echo "Syncing contents of ${BUCKET} to $(pwd)."
 args=()
@@ -90,8 +88,13 @@ while read -r file knownSHA fileSHA; do
   if [[ "${fileSHA}" != "${knownSHA}" ]]; then
     echo
     echo "SHA of file '${file}' differs from known SHA"
-    echo "know SHA: ${knownSHA}"
-    echo "file SHA: ${fileSHA}"
+    if [[ -z "${fileSHA}" ]]; then
+      echo "known SHA: "  # knownSHA was actually empty making what was read "$file $fileSHA"
+      echo "file SHA: ${knownSHA}"
+    else
+      echo "known SHA: ${knownSHA}"
+      echo "file SHA: ${fileSHA}"
+    fi
     let bad+=1
   fi
 


### PR DESCRIPTION
Add go1.12.7 & go1.11.12, default to them.

Add ./sbin/aws.sh to retrieve s3 credentials and setup sync-files.sh to use it.

Sometimes I need the s3 credentials to prune something (unreleased) from the bucket. ./sbin/aws.sh makes that easier.