### PR TITLE
Make the sync'd items publicly readable.

### DIFF
--- a/sbin/sync-files.sh
+++ b/sbin/sync-files.sh
@@ -130,6 +130,7 @@ fi
 echo "All files verified, syncing to s3"
 echo
 args=(--delete)
+args+=(--acl public-read)
 if [[ ${#IGNORE} -gt 0 ]]; then
   for file in ${IGNORE[@]}; do
     args+=(--exclude ${file})


### PR DESCRIPTION
Without this sync'd items aren't publicly available, so the buildpack won't be able to download them. This happened with the releases v120, v121, & v122.

Fixes #348