### PR TITLE
Remove hg and bzr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add go1.12.12, expand go1.12 to go1.12.12, and default to go1.12.12
 * Add go1.13.2, use for go1.13
 * Add go1.12.11, expand go1.12 to go1.12.11, and default to go1.12.11
+* Remove hg and bzr installation as they are now part of the heroku-16 and heroku-18 build images.
 
 ## v131 (2019-10-15)
 * Bump golangci-lint to v1.20.0

--- a/bin/compile
+++ b/bin/compile
@@ -126,45 +126,6 @@ reportVer() {
     esac
 }
 
-ensureHG() {
-    local hgVersion="${1}"
-    local tmp="$(mktemp -d)"
-    local hgPath="${cache}/hg/${hgVersion}"
-    if [ -x "${hgPath}/bin/hg" ]; then
-        step "Using hg v${hgVersion}"
-    else
-        rm -rf "${cache}/hg"
-        mkdir -p "${hgPath}"
-        step "Installing hg ${hgVersion}"
-        ensureFile "mercurial-${hgVersion}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
-        pushd "${tmp}" &> /dev/null
-            python setup.py install --force --home="${hgPath}" &> /dev/null
-        popd &> /dev/null
-    fi
-
-    addToPATH "${hgPath}/bin"
-}
-
-ensureBZR() {
-    local bzrv="${1}"
-    local tmp="$(mktemp -d)"
-    local bzrp="${cache}/bzr/${bzrv}"
-    if [ -x "${bzrp}/bin/bzr" ]; then
-        step "Using bzr v${bzrv}"
-    else
-        rm -rf "${cache}/bzr"
-        mkdir -p "${bzrp}"
-        step "Installing bzr ${bzrv}"
-        ensureFile "bzr-${bzrv}.tar.gz" "${tmp}" "tar -C ${tmp} --strip-components=1 -zxf"
-        pushd "${tmp}" &> /dev/null
-            python setup.py install --force --home="${bzrp}" &> /dev/null
-        popd &> /dev/null
-    fi
-
-    addToPATH "${bzrp}/bin"
-    export PYTHONPATH="${bzrp}/lib/python:${PYTHONPATH}"
-}
-
 ensureGlide() {
     local glideVersion="${1}"
     local gPath="${cache}/glide/${glideVersion}/bin"
@@ -501,9 +462,6 @@ setupProcfile() {
 
 case "${TOOL}" in
     gomodules)
-        ensureBZR "${BazaarVersion}"
-        ensureHG "${MercurialVersion}"
-
         cd ${build}
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
@@ -654,7 +612,6 @@ case "${TOOL}" in
     ;;
     glide)
         ensureGlide "${GlideVersion}"
-        ensureHG "${MercurialVersion}"
 
         # Do this before setupGOPATH as we need ${name} set first
         cd "${build}"

--- a/data.json
+++ b/data.json
@@ -101,7 +101,6 @@
   },
   "test": {
     "assets": [
-      "bzr-2.7.0.tar.gz",
       "dep-v0.5.2-linux-amd64",
       "errors-0.8.0.tar.gz",
       "gb-0.4.4.tar.gz",

--- a/test/fixtures/mod-with-hg-dep/glide.lock
+++ b/test/fixtures/mod-with-hg-dep/glide.lock
@@ -1,0 +1,6 @@
+hash: 25e42040b96d0cc64fde7402a8408952209d0c88d4650ac0599aef6d0ab26abc
+updated: 2016-08-26T11:26:13.178663978-07:00
+imports:
+- name: bitbucket.org/pkg/inflect
+  version: 8961c3750a47b8c0b3e118d52513b97adf85a7e8
+testImports: []

--- a/test/fixtures/mod-with-hg-dep/glide.yaml
+++ b/test/fixtures/mod-with-hg-dep/glide.yaml
@@ -1,0 +1,3 @@
+package: github.com/heroku/fixture
+import:
+- package: bitbucket.org/pkg/inflect

--- a/test/fixtures/mod-with-hg-dep/go.mod
+++ b/test/fixtures/mod-with-hg-dep/go.mod
@@ -1,0 +1,5 @@
+module github.com/heroku/fixture
+
+go 1.12
+
+require bitbucket.org/pkg/inflect v0.0.0-20130829110746-8961c3750a47

--- a/test/fixtures/mod-with-hg-dep/go.sum
+++ b/test/fixtures/mod-with-hg-dep/go.sum
@@ -1,0 +1,2 @@
+bitbucket.org/pkg/inflect v0.0.0-20130829110746-8961c3750a47 h1:XDrztcXGcx7jow3UUE2dpYtdSWVUigoyn8G+shykEtw=
+bitbucket.org/pkg/inflect v0.0.0-20130829110746-8961c3750a47/go.mod h1:8Rt8gHhG+tKz8P3SoEzL/ZNVl25fPhMFKItv5HLIdtY=

--- a/test/fixtures/mod-with-hg-dep/main.go
+++ b/test/fixtures/mod-with-hg-dep/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+import "bitbucket.org/pkg/inflect"
+
+func main() {
+	i := inflect.Rule{}
+	fmt.Println(i)
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -2,6 +2,13 @@
 # See README.md for info on running these tests.
 
 testModWithBZRDep() {
+  if [ "${IMAGE}" = "heroku/cedar:14" ]; then
+    echo "!!!"
+    echo "!!! Skipping this test on heroku/cedar:14"
+    echo "!!! (image doesn't contain bzr)"
+    echo "!!!"
+    return 0
+  fi
   fixture "mod-with-bzr-dep"
 
   assertDetected


### PR DESCRIPTION
They are now part of the heroku-16 and heroku-18 build images, so
buildpacks don't need to install them anymore. *\o/*

I moved the test/fixture for hg from glide to modules.