### PR TITLE
Fix install command missing double quotes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -452,7 +452,7 @@ if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]; then
             xval="${GO_LINKER_SYMBOL}=${GO_LINKER_VALUE}"
         ;;
     esac
-    FLAGS+=(-ldflags "-X ${xval}")
+    FLAGS+=(-ldflags \"-X ${xval}\")
 fi
 
 export GOPATH

--- a/test/run.sh
+++ b/test/run.sh
@@ -1124,7 +1124,7 @@ testGodepLDSymbolValue() {
   assertDetected
 
   compile
-  assertCaptured "Running: go install -v -tags heroku -ldflags -X main.fixture=fixture ."
+  assertCaptured 'Running: go install -v -tags heroku -ldflags "-X main.fixture=fixture" .'
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertCompiledBinaryOutputs "fixture" "fixture"
@@ -1141,7 +1141,7 @@ testGodepLDSymbolGo14Value() {
   assertDetected
 
   compile
-  assertCaptured "Running: go install -v -tags heroku -ldflags -X main.fixture fixture ." #Nothing vendored
+  assertCaptured 'Running: go install -v -tags heroku -ldflags "-X main.fixture fixture" .' #Nothing vendored
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertCompiledBinaryOutputs "fixture" "fixture"


### PR DESCRIPTION
Hi, `FLAGS+=(-ldflags "-X ${xval}")` will gen a command like `-ldflags -X foo/bar.V=$xval`. But we need `-ldflags "-X foo/bar.V=$xval"` to working.