### PR TITLE
go1.12.7 -> go1.12.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 * Download and install bzr when modules are in use.
 
+## v127 (2019-08-15)
+* Add go1.12.8, expand go1.12 to go1.12.8, and default to go1.12.8
+
 ## v126 (2019-07-10)
 * Set the public bit on files uploaded by ./sbin/sync-files.sh so that the files are publicly available.
 

--- a/data.json
+++ b/data.json
@@ -1,11 +1,11 @@
 {
   "Go": {
-    "DefaultVersion": "go1.12.7",
+    "DefaultVersion": "go1.12.8",
     "VersionExpansion": {
       "go1.13": "go1.13beta1",
       "go1.13.0": "go1.13beta1",
       "go1.12.0": "go1.12",
-      "go1.12": "go1.12.7",
+      "go1.12": "go1.12.8",
       "go1.11.0": "go1.11",
       "go1.11": "go1.11.12",
       "go1.10.0": "go1.10",
@@ -108,7 +108,7 @@
       "glide-v0.12.3-linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
       "go1.11.12.linux-amd64.tar.gz",
-      "go1.12.7.linux-amd64.tar.gz",
+      "go1.12.8.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -143,6 +143,18 @@
     "SHA": "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993",
     "URL": "https://storage.googleapis.com/golang/go1.11.1.linux-amd64.tar.gz"
   },
+  "go1.11.10.linux-amd64.tar.gz": {
+    "SHA": "aefaa228b68641e266d1f23f1d95dba33f17552ba132878b65bb798ffa37e6d0",
+    "URL": "https://storage.googleapis.com/golang/go1.11.10.linux-amd64.tar.gz"
+  },
+  "go1.11.11.linux-amd64.tar.gz": {
+    "SHA": "2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775",
+    "URL": "https://storage.googleapis.com/golang/go1.11.11.linux-amd64.tar.gz"
+  },
+  "go1.11.12.linux-amd64.tar.gz": {
+    "SHA": "14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d",
+    "URL": "https://storage.googleapis.com/golang/go1.11.12.linux-amd64.tar.gz"
+  },
   "go1.11.2.linux-amd64.tar.gz": {
     "SHA": "1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d",
     "URL": "https://storage.googleapis.com/golang/go1.11.2.linux-amd64.tar.gz"
@@ -174,18 +186,6 @@
   "go1.11.9.linux-amd64.tar.gz": {
     "SHA": "e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608",
     "URL": "https://storage.googleapis.com/golang/go1.11.9.linux-amd64.tar.gz"
-  },
-  "go1.11.10.linux-amd64.tar.gz": {
-    "SHA": "aefaa228b68641e266d1f23f1d95dba33f17552ba132878b65bb798ffa37e6d0",
-    "URL": "https://storage.googleapis.com/golang/go1.11.10.linux-amd64.tar.gz"
-  },
-  "go1.11.11.linux-amd64.tar.gz": {
-    "SHA": "2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775",
-    "URL": "https://storage.googleapis.com/golang/go1.11.11.linux-amd64.tar.gz"
-  },
-  "go1.11.12.linux-amd64.tar.gz": {
-    "SHA": "14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d",
-    "URL": "https://storage.googleapis.com/golang/go1.11.12.linux-amd64.tar.gz"
   },
   "go1.11.linux-amd64.tar.gz": {
     "SHA": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
@@ -234,6 +234,10 @@
   "go1.12.7.linux-amd64.tar.gz": {
     "SHA": "66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9",
     "URL": "https://storage.googleapis.com/golang/go1.12.7.linux-amd64.tar.gz"
+  },
+  "go1.12.8.linux-amd64.tar.gz": {
+    "SHA": "bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2",
+    "URL": "https://storage.googleapis.com/golang/go1.12.8.linux-amd64.tar.gz"
   },
   "go1.12.linux-amd64.tar.gz": {
     "SHA": "750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13",


### PR DESCRIPTION
This updates the defaults to go1.12.8. The current most version is 1.12.9, but I'm just bumping a single version at a time to be safe.

## Changes
* Adds go1.12.8 
* Adds go1.12.8 as the new default
* s3 bucket should now contain go1.12.8 binary