### PR TITLE
Bump glide to v0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Add go1.13rc2, use for go1.13
 * Add go1.13, use for go1.13
+* Bump Glide to 0.13.3
 
 ## v128 (2019-08-27)
 * Download and install bzr when modules are in use.

--- a/data.json
+++ b/data.json
@@ -73,7 +73,7 @@
     "DefaultVersion": "v0.5.2"
   },
   "Glide": {
-    "DefaultVersion": "v0.12.3"
+    "DefaultVersion": "v0.13.3"
   },
   "Govendor": {
     "DefaultVersion": "1.0.8"
@@ -105,7 +105,7 @@
       "dep-v0.5.2-linux-amd64",
       "errors-0.8.0.tar.gz",
       "gb-0.4.4.tar.gz",
-      "glide-v0.12.3-linux-amd64.tar.gz",
+      "glide-v0.13.3-linux-amd64.tar.gz",
       "go1.10.8.linux-amd64.tar.gz",
       "go1.11.13.linux-amd64.tar.gz",
       "go1.12.9.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -59,6 +59,10 @@
     "SHA": "0e2be5e863464610ebc420443ccfab15cdfdf1c4ab63b5eb25d1216900a75109",
     "URL": "https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
   },
+  "glide-v0.13.3-linux-amd64.tar.gz": {
+    "SHA": "ba5619955a28d7931a9ae38d095fc5fa5acc28e77abc8737a8136c652d9cbb38",
+    "URL": "https://github.com/Masterminds/glide/releases/download/v0.13.3/glide-v0.13.3-linux-amd64.tar.gz"
+  },
   "go.go1.linux-amd64.tar.gz": {
     "SHA": "9c0cb8a5421727f07d805cb77528d966b8e25cecb239b3ec869c2bf7b5058935",
     "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go.go1.linux-amd64.tar.gz"

--- a/test/run.sh
+++ b/test/run.sh
@@ -633,13 +633,6 @@ testGlideWithHgDep() {
     return 0
   fi
 
-  echo "!!!"
-  echo "!!! Skipping this test as Glide uses bitbucket v1.0 API, which is no longer supported"
-  echo "!!! https://developer.atlassian.com/cloud/bitbucket/deprecation-notice-v1-apis/"
-  echo "!!! TODO: move test to go modules"
-  echo "!!!"
-  return 0
-
   fixture "glide-with-hg-dep"
 
   assertDetected


### PR DESCRIPTION
Should allow the use of Glide with bitbucket again.