### PR TITLE
Bump golangci-lint to 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Bump golangci-lint to v1.20.0
 
 ## v130 (2019-09-26)
 * Add go1.13.1, use for go1.13

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -24,5 +24,5 @@ if [ -f "${build}/.golangci.yml" -o -f "${build}/.golangci.toml" -o -f "${build}
     step "/.golangci.{yml,toml,json} detected"
     tmp="$(mktemp -d)"
     mkdir -p "${build}/.heroku/golangci/bin"
-    ensureFile "golangci-lint-1.16.0-linux-amd64.tar.gz" "${tmp}" "tar -C ${build}/.heroku/golangci/bin --strip-components=1 -zxf"
+    ensureFile "golangci-lint-1.20.0-linux-amd64.tar.gz" "${tmp}" "tar -C ${build}/.heroku/golangci/bin --strip-components=1 -zxf"
 fi

--- a/data.json
+++ b/data.json
@@ -114,7 +114,7 @@
       "go1.7.6.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "godep_linux_amd64",
-      "golangci-lint-1.16.0-linux-amd64.tar.gz",
+      "golangci-lint-1.20.0-linux-amd64.tar.gz",
       "govendor_linux_amd64",
       "jq-linux64",
       "mercurial-3.9.tar.gz",

--- a/files.json
+++ b/files.json
@@ -504,6 +504,10 @@
     "SHA": "5343fc3ffcbb9910925f4047ec3c9f2e9623dd56a72a17ac76fb2886abc0976b",
     "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.16.0/golangci-lint-1.16.0-linux-amd64.tar.gz"
   },
+  "golangci-lint-1.20.0-linux-amd64.tar.gz": {
+    "SHA": "5a638cba74fbfb6e11b9dce38e8caf3f18e998b6548118116d631ebcae3ebac5",
+    "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.20.0/golangci-lint-1.20.0-linux-amd64.tar.gz"
+  },
   "govendor_linux_amd64": {
     "LocalName": "govendor",
     "SHA": "90c587c3c2dffa242ed62c62426cd85bae8a74165d5434ccc0c31ee8e25d2588",

--- a/test/fixtures/mod-deps-vendored-with-tests/go.mod
+++ b/test/fixtures/mod-deps-vendored-with-tests/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 )
+
+go 1.13

--- a/test/fixtures/mod-deps-vendored-with-tests/main_test.go
+++ b/test/fixtures/mod-deps-vendored-with-tests/main_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func Test_BasicTest(t *testing.T) {
 	one := 1
-	if 1 != one {
+	if one != 1 {
 		t.Fatalf("expected 1 == 1")
 	}
 }

--- a/test/fixtures/mod-deps-with-tests/go.mod
+++ b/test/fixtures/mod-deps-with-tests/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 )
+
+go 1.13

--- a/test/fixtures/mod-deps-with-tests/main_test.go
+++ b/test/fixtures/mod-deps-with-tests/main_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func Test_BasicTest(t *testing.T) {
 	one := 1
-	if 1 != one {
+	if one != 1 {
 		t.Fatalf("expected 1 == 1")
 	}
 }


### PR DESCRIPTION
This fixes issues when using golangci-lint with projects that have moved to go1.13.