### PR TITLE
sbin/sync-files: verify checksums serially

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Update shunit2
+* sbin/sync-files.sh: verify checksums serially
 
 ## v138 (2020-03-13)
 * Add go1.13.8


### PR DESCRIPTION
Trying to run shasum many times concurrently doesn't seem to work at
least on my laptop. While getting some concurrency would be nice,
prefer this serial approach for now which works reliably.

I used this to sync go1.14 (PR incoming) and tested the checksum verification by adding `echo hi > stdlib.sh.v8` after the initial s3 sync, giving it a bad checksum.