### PR TITLE
Travis config + badge cleanup [changelog skip]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: bash
-sudo: required
 services:
 - docker
 before_install:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Heroku Buildpack for Go
 
-[![travis ci](https://travis-ci.org/heroku/heroku-buildpack-go.svg?branch=master)](https://travis-ci.org/heroku/heroku-buildpack-go)
+[![travis ci](https://travis-ci.com/heroku/heroku-buildpack-go.svg?branch=master)](https://travis-ci.com/heroku/heroku-buildpack-go)
 
 ![Heroku Buildpack for Go](https://cloud.githubusercontent.com/assets/51578/15877053/53506724-2cdf-11e6-878c-e2ef60ba741f.png)
 


### PR DESCRIPTION
* The `sudo: required` entry is redundant as of:
  https://blog.travis-ci.com/2017-08-31-trusty-as-default-status
* The current badge target reports:
  "This repository was migrated and is now building on travis-ci.com"