### PR TITLE
compile: set GOPATH earlier for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Set GOPATH earlier when using modules
 
 ## v141 (2020-04-21)
 * Add Heroku-20 to the Travis test matrix

--- a/bin/compile
+++ b/bin/compile
@@ -465,6 +465,14 @@ case "${TOOL}" in
     gomodules)
         cd ${build}
 
+        export GOBIN="${build}/bin"
+        if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
+            export GOPATH="${build}/.heroku/go-path"
+            mkdir -p $GOPATH # ensure that it's created
+        else
+            export GOPATH="${cache}/go-path"
+        fi
+
         # TODO: Check the desired language version (eg `go mod edit -json | jq -r '.Go'`)
         # and only do this if it's <1.14. The 1.14 release and beyond handles this automatically
         # when the desired language version is 1.14+ and vendoring should be used.
@@ -511,13 +519,6 @@ case "${TOOL}" in
         massagePkgSpecForVendor
 
         unset GIT_DIR # unset git dir or it will mess with goinstall
-        export GOBIN="${build}/bin"
-        if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
-            export GOPATH="${build}/.heroku/go-path"
-            mkdir -p $GOPATH # ensure that it's created
-        else
-            export GOPATH="${cache}/go-path"
-        fi
         if [[ -f bin/go-pre-compile ]]; then
             step "Running bin/go-pre-compile hook"
             chmod a+x bin/go-pre-compile

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -108,10 +108,14 @@ compile() {
 }
 
 dotest() {
+  # On Heroku CI, test-compile and test are run in such a way that the
+  # provided BUILD_DIR is the same as HOME. Simulate that here to get
+  # better fidelity. For example, this ensures that the default GOPATH of
+  # $HOME/go doesn't cause issues.
   echo "* test-compile"
-  capture "${BUILDPACK_HOME}/bin/test-compile" "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
+  HOME="${BUILD_DIR}" capture "${BUILDPACK_HOME}/bin/test-compile" "${BUILD_DIR}" "${CACHE_DIR}" "${ENV_DIR}"
   echo "* test"
-  continue_capture "${BUILDPACK_HOME}/bin/test" "${BUILD_DIR}" "${ENV_DIR}"
+  HOME="${BUILD_DIR}" continue_capture "${BUILDPACK_HOME}/bin/test" "${BUILD_DIR}" "${ENV_DIR}"
 }
 
 release() {


### PR DESCRIPTION
In https://github.com/heroku/heroku-buildpack-go/pull/396 the explicit
`-mod=vendor` was removed from the `go list` command used to find main
packages to install. This enabled it to fetch modules as necessary for
listing if vendoring was not being used. When modules are fetched,
they are fetched into $GOPATH/pkg/mod. If GOPATH is not set, it
defaults to $HOME/go.

In build mode, at least Heroku runs compile with a build directory
that is not the same as $HOME. In test mode, however, at least Heroku
CI runs test-compile with a build directory that is equal to
$HOME.

When this initial `go list` was being run, GOPATH was not yet set,
which in test mode downloaded modules to $HOME/go. Later, once `go
test ./...` or similar was run in $HOME, the source of the downloaded
modules was being considered. This caused errors such as:

go: directory go/pkg/mod/github.com/gorilla/mux@v1.6.2 outside available modules

To fix this, set GOPATH for modules earlier, before `go list` is run.

To get better test fidelity, run testpack tests with HOME set to the
temporary build directory.