### PR TITLE
[changelog skip] Fix PR edit check

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -1,6 +1,8 @@
 name: Check Changelog
 
-on: [pull_request]
+on:
+ pull_request:
+  types: [opened, reopened, edited, synchronize]
 
 jobs:
  build:


### PR DESCRIPTION

Previously when a PR title was edited, the "check for changelog" script would not fire. This means if someone edited it to add a "[changelog skip]" that the check would still show to be failing. This PR adds additional triggers for the check so that when the PR is edited, the check will re-run.