### PR TITLE
Use the go version in go.mod if no +heroku comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 ## v155 (2021-09-13)
 * Add go1.16.8, use for go1.16
 * Add go1.17.1, use for go1.17
+* Use the go version in go.mod if no +heroku comment is found (#378)
 
 ## v154 (2021-08-18)
 * Add go1.17

--- a/data.json
+++ b/data.json
@@ -118,6 +118,7 @@
       "go1.10.8.linux-amd64.tar.gz",
       "go1.11.13.linux-amd64.tar.gz",
       "go1.12.17.linux-amd64.tar.gz",
+      "go1.13.15.linux-amd64.tar.gz",
       "go1.14.2.linux-amd64.tar.gz",
       "go1.15.15.linux-amd64.tar.gz",
       "go1.16rc1.linux-amd64.tar.gz",

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -330,6 +330,7 @@ determineTool() {
         info "Detected go modules via go.mod"
         step ""
         ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
+        ver=${ver:-$(awk '{ if ($1 == "go" ) { print "go" $2; exit } }' ${goMOD})} 
         name=$(awk '{ if ($1 == "module" ) { gsub(/"/, "", $2); print $2; exit } }' < ${goMOD})
         info "Detected Module Name: ${name}"
         step ""

--- a/test/run.sh
+++ b/test/run.sh
@@ -367,7 +367,7 @@ testModPrivateProxy() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured
+  assertGoInstallCaptured "1.15.15"
   assertGoInstallOnlyFixturePackageCaptured
 
   assertCapturedExitSuccess

--- a/test/run.sh
+++ b/test/run.sh
@@ -367,7 +367,7 @@ testModPrivateProxy() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured "1.15.15"
+  assertGoInstallCaptured "go1.15.15"
   assertGoInstallOnlyFixturePackageCaptured
 
   assertCapturedExitSuccess


### PR DESCRIPTION
`go` records own version in `go.mod` as

    go 1.13

This fix should let the buildpack to detect it if nothing else is set.
https://github.com/heroku/heroku-buildpack-go/issues/378#issuecomment-629665034