### PR TITLE
Git submodules support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -112,7 +112,7 @@ expandVer() {
 reportVer() {
     local ver="${1}"
     mcount "version.go.$ver"
-
+    
     case $ver in
         devel*)
             warn ""
@@ -132,7 +132,7 @@ ensureGlide() {
     local gBin="${gPath}/glide"
     local gFile="glide-${glideVersion}-linux-amd64.tar.gz"
     local targetFile="${gPath}/${gFile}"
-
+    
     if [ -x "${gBin}" ]; then
         step "Using glide ${glideVersion}"
         addToPATH "${gPath}"
@@ -151,7 +151,7 @@ ensureMigrateTool() {
     local tmp="$(mktemp -d)"
     local mtPath="${cache}/${t}/${mtVersion}"
     local targetFile="${build}/bin/migrate"
-
+    
     if [ -x "targetFile" ]; then
         warning '"migrate" binary already exists in ~/bin, not installing '${t}
     else
@@ -166,13 +166,13 @@ ensureMigrateTool() {
 
 wantAdditionalTool() {
     local addt="${1}"
-
+    
     case "${TOOL}" in
         govendor)
             <${vendorJSON} jq -e '.heroku.additionalTools | contains(["'${addt}'"])' &> /dev/null
         ;;
         dep)
-          <${depTOML} tq '$.metadata.heroku["additional-tools"]' | grep "^${addt}$" &> /dev/null
+            <${depTOML} tq '$.metadata.heroku["additional-tools"]' | grep "^${addt}$" &> /dev/null
         ;;
         *)
             false
@@ -183,7 +183,7 @@ wantAdditionalTool() {
 additionalToolVersion() {
     local addt="${1}"
     local default="${2}"
-
+    
     local tv=""
     case "${TOOL}" in
         govendor)
@@ -195,7 +195,7 @@ additionalToolVersion() {
             tv="$(echo $f | cut -d @ -f 2)"
         ;;
     esac
-
+    
     echo $tv
 }
 
@@ -217,7 +217,7 @@ installMattesMigrateIfWanted() {
         warn ""
         warn "Note: Supported Golang Migrate versions start at v3.4.0"
         warn ""
-
+        
         ensureMigrateTool $t $(additionalToolVersion $t ${MattesMigrateVersion})
     fi
 }
@@ -236,14 +236,14 @@ ensureGB() {
         rm -rf "${cache}/gb/*"
         ensureFile "${pkgErrsFile}" "${pkgErrorsPath}" "tar -C ${pkgErrorsPath} --strip-components=1 -zxf"
         rm -f "${pkgErrorsPath}/${pkgErrsFile}"
-
+        
         ensureFile "${gbFile}" "${gbPath}" "tar -C ${gbPath} --strip-components=1 -zxf"
         rm -f "${gbPath}/${gbFile}"
-
+        
         start "Installing GB v${GBVersion}"
-            pushd "${gbPath}" &> /dev/null
-                go install ./...
-            popd &> /dev/null
+        pushd "${gbPath}" &> /dev/null
+        go install ./...
+        popd &> /dev/null
         finished
     fi
 }
@@ -276,30 +276,30 @@ ensureGo() {
                 goFile="${goVersion}.linux-amd64.tar.gz"
             ;;
         esac
-
+        
         step "${txt}"
         ensureFile "${goFile}" "${goPath}" "tar -C ${goPath} --strip-components=1 -zxf"
         rm -f "${goPath}/${goFile}"
-
+        
         case "${goVersion}" in
             devel*)
                 pushd "${cache}" &> /dev/null
-                    mkdir -p "${goVersion}"
-                    pushd "${goVersion}" &> /dev/null
-                        local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
-                        local url="https://github.com/golang/go/archive/$sha.tar.gz"
-                        start "Downloading development Go version ${goVersion}"
-                            ${CURL} ${url} | tar zxf -
-                            mv go-${sha}* go
-                        finished
-                        step "Compiling development Go version ${goVersion}"
-                        pushd go/src &> /dev/null
-                            echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
-                            GOROOT_BOOTSTRAP=$(pushd ${cache}/${bGoVersion}/go > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
-                        popd &> /dev/null
-                        go/bin/go version
-                        rm -rf "${goPath}"
-                    popd &> /dev/null
+                mkdir -p "${goVersion}"
+                pushd "${goVersion}" &> /dev/null
+                local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
+                local url="https://github.com/golang/go/archive/$sha.tar.gz"
+                start "Downloading development Go version ${goVersion}"
+                ${CURL} ${url} | tar zxf -
+                mv go-${sha}* go
+                finished
+                step "Compiling development Go version ${goVersion}"
+                pushd go/src &> /dev/null
+                echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
+                GOROOT_BOOTSTRAP=$(pushd ${cache}/${bGoVersion}/go > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
+                popd &> /dev/null
+                go/bin/go version
+                rm -rf "${goPath}"
+                popd &> /dev/null
                 popd &> /dev/null
                 goPath="${cache}/${goVersion}/go"
             ;;
@@ -307,13 +307,13 @@ ensureGo() {
             ;;
         esac
     fi
-
+    
     export GOROOT="${goPath}"
     PATH="${goPath}/bin:${PATH}"
-
+    
     # Export GOCACHE if Go >= 1.10
     if go env | grep -q '^GOCACHE='; then
-      export GOCACHE="${cache}/go-build-cache"
+        export GOCACHE="${cache}/go-build-cache"
     fi
 }
 
@@ -356,7 +356,7 @@ warnPackageSpecOverride() {
 setupGOPATH() {
     local name="${1}"
     local t="$(mktemp -d)"
-
+    
     if [ "${GO_SETUP_GOPATH_IN_IMAGE}" = "true" ]; then
         mv -t ${t} ${build}/*
         GOPATH="${build}"
@@ -365,18 +365,19 @@ setupGOPATH() {
         GOPATH="${t}/.go"
         echo export GOBIN="${build}/bin"
     fi
-
+    
     local src="${GOPATH}/src/${name}"
     mkdir -p "${src}"
     mkdir -p "${build}/bin"
     mv -t "${src}" "${t}"/*
-
+    
     echo "GOPATH=${GOPATH}"
     echo "src=${src}"
 }
 
 installPkgs() {
     if [ "${TOOL}" == "gomodules" ]; then
+        info "Finding go.mod directory in build path: '${build}'"
         pkg_dir=$( find ${build} -name go.mod | grep -v vendor | xargs dirname )
         step "Running: go install -v ${FLAGS[@]} in '${pkgs_dir}' path"
         cd ${pkg_dir}
@@ -431,8 +432,8 @@ export GOPATH
 mcount "pkgmanagement.$TOOL"
 
 mainPackagesInModule() {
-  # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
-  go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./... 2>/dev/null
+    # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
+    go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./... 2>/dev/null
 }
 
 setupProcfile() {
@@ -457,7 +458,7 @@ setupProcfile() {
         local line="web: bin/$(echo ${pf[0]} | cut -d / -f 2)"
         echo "${line}" > ${build}/Procfile
         info "\t\t${line}"
-    elif [ ${#pf[@]} -gt 1 ]; then
+        elif [ ${#pf[@]} -gt 1 ]; then
         for pfl in "${pf[@]}"; do
             echo "${pfl}" >> ${build}/Procfile
             info "\t\t${pfl}"
@@ -471,9 +472,16 @@ setupProcfile() {
 
 case "${TOOL}" in
     gomodules)
-        export GOBIN="${build}/bin"
         cd ${build}
-
+        
+        export GOBIN="${build}/bin"
+        if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
+            export GOPATH="${build}/.heroku/go-path"
+            mkdir -p $GOPATH # ensure that it's created
+        else
+            export GOPATH="${cache}/go-path"
+        fi
+        
         # TODO: Check the desired language version (eg `go mod edit -json | jq -r '.Go'`)
         # and only do this if it's <1.14. The 1.14 release and beyond handles this automatically
         # when the desired language version is 1.14+ and vendoring should be used.
@@ -481,7 +489,7 @@ case "${TOOL}" in
         if [ -d "${build}/vendor" -a -s "${build}/go.sum" ]; then
             FLAGS+=(-mod=vendor)
         fi
-
+        
         step "Determining packages to install"
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
         if [ -z "${pkgs}" ]; then
@@ -510,62 +518,61 @@ case "${TOOL}" in
                 mcount "pkginstall.heroku_install"
             fi
         fi
-
+        
         if [[ "${pkgs}" =~ "..." ]]; then
             mcount "package_spec.contains.dot_dot_dot"
         fi
-
+        
         warnPackageSpecOverride
         handleDefaultPkgSpec
         massagePkgSpecForVendor
-
+        
         unset GIT_DIR # unset git dir or it will mess with goinstall
         if [[ -f bin/go-pre-compile ]]; then
             step "Running bin/go-pre-compile hook"
             chmod a+x bin/go-pre-compile
             bin/go-pre-compile
         fi
-
+        
         installPkgs
-
+        
         if [[ -f bin/go-post-compile ]]; then
             step "Running bin/go-post-compile hook"
             chmod a+x bin/go-post-compile
             bin/go-post-compile
         fi
-        build=${build_bkp}
     ;;
     dep)
         eval "$(setupGOPATH ${name})"
         depTOML="${src}/Gopkg.toml"
-
+        
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${depTOML} tq '$.metadata.heroku["install"]')}
         if [ -z "${pkgs}" ]; then
             pkgs="default"
         fi
         warnPackageSpecOverride
         handleDefaultPkgSpec
-
+        
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
-
+        
         if [ "$(< ${depTOML} tq '$.metadata.heroku["ensure"]')" != "false" ]; then
             ensureInPath "dep-${DepVersion}-linux-amd64" "${cache}/dep/bin"
             step "Fetching any unsaved dependencies (dep ensure)"
             dep ensure
         fi
         massagePkgSpecForVendor
-
+        
         installPkgs
     ;;
     godep)
         eval "$(setupGOPATH ${name})"
         godepsJSON="${src}/Godeps/Godeps.json"
-
+        
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${godepsJSON} jq -r 'if .Packages then .Packages | join(" ") else "default" end')}
         warnPackageSpecOverride
         handleDefaultPkgSpec
-
+        
         UseGodepCommand="false" # Default to not wrapping go install with godep (vendor)
         if [ -d "${src}/Godeps/_workspace/src" ]; then
             UseGodepCommand="true"
@@ -585,12 +592,12 @@ case "${TOOL}" in
                 warn ""
             fi
         fi
-
+        
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
         if [ "${UseGodepCommand}" = "true" ]; then
             ensureInPath "godep_linux_amd64" "${cache}/godep/bin"
-
+            
             step "Running: godep go install -v ${FLAGS[@]} ${pkgs}"
             godep go install -v "${FLAGS[@]}" ${pkgs} 2>&1
         else
@@ -600,56 +607,56 @@ case "${TOOL}" in
     ;;
     govendor)
         ensureInPath "govendor_linux_amd64" "${cache}/govendor/bin"
-
+        
         eval "$(setupGOPATH ${name})"
         vendorJSON="${src}/vendor/vendor.json"
-
+        
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(<${vendorJSON} jq -r 'if .heroku.install then .heroku.install | join(" ") else "default" end')}
         warnPackageSpecOverride
         handleDefaultPkgSpec
-
+        
         unset GIT_DIR # unset git dir or it will mess with goinstall
         cd "${src}"
-
+        
         if [ "$(<${vendorJSON} jq -r '.heroku.sync')" != "false" ]; then
             step "Fetching any unsaved dependencies (govendor sync)"
             govendor sync
         fi
         massagePkgSpecForVendor
-
+        
         installPkgs
     ;;
     glide)
         ensureGlide "${GlideVersion}"
-
+        
         # Do this before setupGOPATH as we need ${name} set first
         cd "${build}"
         name=$(glide name 2>/dev/null)
-
+        
         eval "$(setupGOPATH ${name})"
-
+        
         pkgs=${GO_INSTALL_PACKAGE_SPEC:-"default"}
         handleDefaultPkgSpec
-
+        
         unset GIT_DIR
         cd "${src}"
-
+        
         if [[ "${GLIDE_SKIP_INSTALL}" != "true" ]]; then
             step "Fetching any unsaved dependencies (glide install)"
             glide install 2>&1
         fi
-
+        
         massagePkgSpecForVendor
-
+        
         installPkgs
     ;;
     gb)
         ensureGB "${GBVersion}"
-
+        
         cd $build
         step "Running: gb build ${FLAGS[@]}"
         gb build "${FLAGS[@]}" 2>&1
-
+        
         step "Post Compile Cleanup"
         for f in bin/*-heroku; do
             mv "$f" "${f/-heroku}"
@@ -665,7 +672,7 @@ _newOrUpdatedBinFiles=$(binDiff)
 info ""
 info "Installed the following binaries:"
 for fyle in ${_newOrUpdatedBinFiles}; do
-  info "\t\t${fyle}"
+    info "\t\t${fyle}"
 done
 
 if [ -n "${src}" -a "${src}" != "${build}" -a -e "${src}/Procfile" ]; then
@@ -686,20 +693,20 @@ echo 'PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
 
 if [ "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true" ]; then
     start "Copying go tool chain to \$GOROOT=\$HOME/.heroku/go"
-        mkdir -p "${build}/.heroku/go"
-        cp -a "${GOROOT}/"* "${build}/.heroku/go"
-        echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
-        echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
+    mkdir -p "${build}/.heroku/go"
+    cp -a "${GOROOT}/"* "${build}/.heroku/go"
+    echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
+    echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
     finished
     if which ${TOOL} &> /dev/null; then
-      step "Copying ${TOOL} binary"
-      cp $(which ${TOOL}) "${build}/bin"
+        step "Copying ${TOOL} binary"
+        cp $(which ${TOOL}) "${build}/bin"
     fi
 fi
 
 if [ "${GO_SETUP_GOPATH_IN_IMAGE}" = "true" ]; then
     start "Cleaning up \$GOPATH/pkg"
-        rm -rf $GOPATH/pkg
+    rm -rf $GOPATH/pkg
     finished
     echo 'export GOPATH=$HOME' > "${build}/.profile.d/zzgopath.sh"  #Try to make sure it's down in towards the end
     echo 'cd $GOPATH/src/'${name} >> "${build}/.profile.d/zzgopath.sh" # because of this

--- a/bin/compile
+++ b/bin/compile
@@ -376,8 +376,15 @@ setupGOPATH() {
 }
 
 installPkgs() {
-    step "Running: go install -v ${FLAGS[@]} ${pkgs}"
-    go install -v "${FLAGS[@]}" ${pkgs} 2>&1
+    if [ "${TOOL}" == "gomodules" ]; then
+        cd ${pkgs}
+        step "Running: go install -v ${FLAGS[@]} in '${pkgs}' path"
+        go install -v "${FLAGS[@]}" 2>&1
+        cd ${build}
+    else
+        step "Running: go install -v ${FLAGS[@]} ${pkgs}"
+        go install -v "${FLAGS[@]}" ${pkgs} 2>&1
+    fi
 }
 
 loadEnvDir "${env_dir}"
@@ -464,16 +471,6 @@ setupProcfile() {
 case "${TOOL}" in
     gomodules)
         export GOBIN="${build}/bin"
-        
-        build_bkp=${build}
-
-        if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
-            export GOPATH="${build}/.heroku/go-path"
-            mkdir -p $GOPATH # ensure that it's created
-        else
-            export GOPATH="${cache}/go-path"
-        fi
-
         cd ${build}
 
         # TODO: Check the desired language version (eg `go mod edit -json | jq -r '.Go'`)

--- a/bin/compile
+++ b/bin/compile
@@ -387,8 +387,8 @@ trap clearGitCredHelper INT TERM EXIT
 
 FLAGS=(-tags heroku)
 
-if [ ! -z "${GO_SPEC_TOOL}"]; then
-    export goMOD="${GO_SPEC_TOOL}"
+if [ ! -z "${GO_SPEC_BUILD_DIR}"]; then
+    export goMOD="${GO_SPEC_BUILD_DIR}/go.mod"
 fi
 
 determineTool

--- a/bin/compile
+++ b/bin/compile
@@ -387,7 +387,7 @@ trap clearGitCredHelper INT TERM EXIT
 
 FLAGS=(-tags heroku)
 
-if [ ! -z "${GO_SPEC_BUILD_DIR}"]; then
+if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
     export goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
     step "Overreading go.mod path: ${goMOD}"
 fi
@@ -472,7 +472,7 @@ case "${TOOL}" in
         
         build_bkp=${build}
         
-        if [ ! -z "${GO_SPEC_BUILD_DIR}" ]; then
+        if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
             build="${build}/${GO_SPEC_BUILD_DIR}"
         fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -388,7 +388,8 @@ trap clearGitCredHelper INT TERM EXIT
 FLAGS=(-tags heroku)
 
 if [ ! -z "${GO_SPEC_BUILD_DIR}"]; then
-    export goMOD="${GO_SPEC_BUILD_DIR}/go.mod"
+    export goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
+    step "Overreading go.mod path: ${goMOD}"
 fi
 
 determineTool

--- a/bin/compile
+++ b/bin/compile
@@ -389,6 +389,10 @@ FLAGS=(-tags heroku)
 
 determineTool
 
+if [ ! -z "${GO_SPEC_TOOL}"]; then
+    TOOL="${GO_SPEC_TOOL}"
+fi
+
 ver=$(expandVer $ver)
 
 # If $GO_LINKER_SYMBOL and GO_LINKER_VALUE are set, tell the linker to DTRT
@@ -463,15 +467,22 @@ setupProcfile() {
 
 case "${TOOL}" in
     gomodules)
-        cd ${build}
-
         export GOBIN="${build}/bin"
+        
+        build_bkp=${build}
+        
+        if [ ! -z "${GO_SPEC_BUILD_DIR}" ]; then
+            build="${GO_SPEC_BUILD_DIR}"
+        fi
+
         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
             export GOPATH="${build}/.heroku/go-path"
             mkdir -p $GOPATH # ensure that it's created
         else
             export GOPATH="${cache}/go-path"
         fi
+
+        cd ${build}
 
         # TODO: Check the desired language version (eg `go mod edit -json | jq -r '.Go'`)
         # and only do this if it's <1.14. The 1.14 release and beyond handles this automatically
@@ -532,6 +543,7 @@ case "${TOOL}" in
             chmod a+x bin/go-post-compile
             bin/go-post-compile
         fi
+        build=${build_bkp}
     ;;
     dep)
         eval "$(setupGOPATH ${name})"

--- a/bin/compile
+++ b/bin/compile
@@ -387,11 +387,11 @@ trap clearGitCredHelper INT TERM EXIT
 
 FLAGS=(-tags heroku)
 
-determineTool
-
 if [ ! -z "${GO_SPEC_TOOL}"]; then
-    TOOL="${GO_SPEC_TOOL}"
+    export goMOD="${GO_SPEC_TOOL}"
 fi
+
+determineTool
 
 ver=$(expandVer $ver)
 

--- a/bin/compile
+++ b/bin/compile
@@ -469,6 +469,7 @@ case "${TOOL}" in
         
         if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
             step "GO_SPEC_BUILD_DIR isn't set using default: ${build}"
+            step "Current GO_SPEC_BUILD_DIR value: '${GO_SPEC_BUILD_DIR}'"
         else
             build="${build}/${GO_SPEC_BUILD_DIR}"
             step "Using new build path: ${build}"

--- a/bin/compile
+++ b/bin/compile
@@ -377,8 +377,9 @@ setupGOPATH() {
 
 installPkgs() {
     if [ "${TOOL}" == "gomodules" ]; then
-        cd ${pkgs}
-        step "Running: go install -v ${FLAGS[@]} in '${pkgs}' path"
+        pkg_dir=$( find . -name go.mod | grep -v vendor | xargs dirname )
+        step "Running: go install -v ${FLAGS[@]} in '${pkgs_dir}' path"
+        cd ${pkg_dir}
         go install -v "${FLAGS[@]}" 2>&1
         cd ${build}
     else

--- a/bin/compile
+++ b/bin/compile
@@ -469,6 +469,9 @@ case "${TOOL}" in
         
         if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
             build="${build}/${GO_SPEC_BUILD_DIR}"
+            step "Changing build path: ${build}"
+        else
+            step "Keeping build path: ${build}"
         fi
 
         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -472,7 +472,7 @@ case "${TOOL}" in
         build_bkp=${build}
         
         if [ ! -z "${GO_SPEC_BUILD_DIR}" ]; then
-            build="${GO_SPEC_BUILD_DIR}"
+            build="${build}/${GO_SPEC_BUILD_DIR}"
         fi
 
         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -387,11 +387,6 @@ trap clearGitCredHelper INT TERM EXIT
 
 FLAGS=(-tags heroku)
 
-if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
-    export goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
-    step "Overreading go.mod path: ${goMOD}"
-fi
-
 determineTool
 
 ver=$(expandVer $ver)

--- a/bin/compile
+++ b/bin/compile
@@ -466,14 +466,6 @@ case "${TOOL}" in
         export GOBIN="${build}/bin"
         
         build_bkp=${build}
-        
-        if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
-            step "GO_SPEC_BUILD_DIR isn't set using default: ${build}"
-            step "Current GO_SPEC_BUILD_DIR value: '${GO_SPEC_BUILD_DIR}'"
-        else
-            build="${build}/${GO_SPEC_BUILD_DIR}"
-            step "Using new build path: ${build}"
-        fi
 
         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then
             export GOPATH="${build}/.heroku/go-path"

--- a/bin/compile
+++ b/bin/compile
@@ -377,7 +377,7 @@ setupGOPATH() {
 
 installPkgs() {
     if [ "${TOOL}" == "gomodules" ]; then
-        pkg_dir=$( find . -name go.mod | grep -v vendor | xargs dirname )
+        pkg_dir=$( find ${build} -name go.mod | grep -v vendor | xargs dirname )
         step "Running: go install -v ${FLAGS[@]} in '${pkgs_dir}' path"
         cd ${pkg_dir}
         go install -v "${FLAGS[@]}" 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -467,11 +467,11 @@ case "${TOOL}" in
         
         build_bkp=${build}
         
-        if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
-            build="${build}/${GO_SPEC_BUILD_DIR}"
-            step "Changing build path: ${build}"
+        if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
+            step "GO_SPEC_BUILD_DIR isn't set using default: ${build}"
         else
-            step "Keeping build path: ${build}"
+            build="${build}/${GO_SPEC_BUILD_DIR}"
+            step "Using new build path: ${build}"
         fi
 
         if [ "${GO_SETUP_GOPATH_FOR_MODULE_CACHE}" = "true" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -379,7 +379,7 @@ installPkgs() {
     if [ "${TOOL}" == "gomodules" ]; then
         info "Finding go.mod directory in build path: '${build}'"
         pkg_dir=$( find ${build} -name go.mod | grep -v vendor | xargs dirname )
-        step "Running: go install -v ${FLAGS[@]} in '${pkgs_dir}' path"
+        step "Running: go install -v ${FLAGS[@]} in '${pkg_dir}' path"
         cd ${pkg_dir}
         go install -v "${FLAGS[@]}" 2>&1
         cd ${build}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -9,7 +9,7 @@ depTOML="${build}/Gopkg.toml"
 godepsJSON="${build}/Godeps/Godeps.json"
 vendorJSON="${build}/vendor/vendor.json"
 glideYAML="${build}/glide.yaml"
-goMOD="${build}/go.mod"
+goMOD=$( find ${build} -name go.mod | grep -v vendor )
 
 steptxt="----->"
 GREEN='\033[1;32m'
@@ -321,13 +321,6 @@ supportsGoModules() {
 }
 
 determineTool() {
-    if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
-        step "GO_SPEC_BUILD_DIR isn't set using defaul: ${goMOD}"
-        step "Current GO_SPEC_BUILD_DIR value: '${GO_SPEC_BUILD_DIR}'"
-    else
-        goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
-        step "Using new module path: ${goMOD}"
-    fi
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
         step ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,6 +10,10 @@ godepsJSON="${build}/Godeps/Godeps.json"
 vendorJSON="${build}/vendor/vendor.json"
 glideYAML="${build}/glide.yaml"
 goMOD="${build}/go.mod"
+if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
+    goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
+    step "Overreading go.mod path: ${goMOD}"
+fi
 
 steptxt="----->"
 GREEN='\033[1;32m'

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -322,7 +322,8 @@ supportsGoModules() {
 
 determineTool() {
     if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
-        step "GO_SPEC_BUILD_DIR isn't set using defaul: ${goMOD} "
+        step "GO_SPEC_BUILD_DIR isn't set using defaul: ${goMOD}"
+        step "Current GO_SPEC_BUILD_DIR value: '${GO_SPEC_BUILD_DIR}'"
     else
         goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
         step "Using new module path: ${goMOD}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,10 +10,6 @@ godepsJSON="${build}/Godeps/Godeps.json"
 vendorJSON="${build}/vendor/vendor.json"
 glideYAML="${build}/glide.yaml"
 goMOD="${build}/go.mod"
-if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
-    goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
-    step "Overreading go.mod path: ${goMOD}"
-fi
 
 steptxt="----->"
 GREEN='\033[1;32m'
@@ -325,6 +321,12 @@ supportsGoModules() {
 }
 
 determineTool() {
+    if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
+        goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
+        step "Overreading go.mod path: ${goMOD}"
+    else
+        step "go.mod path not overreated: ${goMOD}"
+    fi
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
         step ""

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -321,11 +321,11 @@ supportsGoModules() {
 }
 
 determineTool() {
-    if [ "${GO_SPEC_BUILD_DIR}X" != "X" ]; then
-        goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
-        step "Overreading go.mod path: ${goMOD}"
+    if [ -z "${GO_SPEC_BUILD_DIR}" ]; then
+        step "GO_SPEC_BUILD_DIR isn't set using defaul: ${goMOD} "
     else
-        step "go.mod path not overreated: ${goMOD}"
+        goMOD="${build}/${GO_SPEC_BUILD_DIR}/go.mod"
+        step "Using new module path: ${goMOD}"
     fi
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"


### PR DESCRIPTION
Hi,

I'm trying to build my application and deploy it in heroku. I want divide my application in back y front using git submodules. The problem begins when golang buildpack try to check if the project use go.mod or other tool. In my project use standard go modules and the `common.sh` look for `go.mod` file in the root of project (or `${build}` path).

In my branch change the way to get `go.mod` file path and the installation process in `compile` shellscript.

I hope that my contribution be helpful.

Thanks in the advance!