### PR TITLE
CHANGELOG: fix go1.15.7 typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v150 (2021-01-21)
 * Add go1.14.14, use for go1.14
-* Add go1.15.6, use for go1.15
+* Add go1.15.7, use for go1.15
 
 ## v149 (2020-12-07)
 * Add go1.14.11


### PR DESCRIPTION
https://github.com/heroku/heroku-buildpack-go/pull/441#pullrequestreview-573459465