### PR TITLE
Makefile, test: drop cedar-14 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
 - make IMAGE=$IMAGE test
 env:
   matrix:
-  - IMAGE=heroku/cedar:14
   - IMAGE=heroku/heroku:16-build
   - IMAGE=heroku/heroku:18-build
   - IMAGE=heroku/heroku:20-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Drop cedar-14 from test matrix
+* Remove skipping of tests on cedar-14
+* Update Makefile's default IMAGE to heroku/heroku:20-build
 
 ## v151 (2021-02-01)
 * Add go1.16rc1, use for go1.16

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TMP := ''
-IMAGE := heroku/heroku:16-build
+IMAGE := heroku/heroku:20-build
 BASH_COMMAND := /bin/bash
 GO_BUCKET_URL := file:///buildpack/test/assets
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -2,13 +2,6 @@
 # See README.md for info on running these tests.
 
 testModWithBZRDep() {
-  if [ "${IMAGE}" = "heroku/cedar:14" ]; then
-    echo "!!!"
-    echo "!!! Skipping this test on heroku/cedar:14"
-    echo "!!! (image doesn't contain bzr)"
-    echo "!!!"
-    return 0
-  fi
   fixture "mod-with-bzr-dep"
 
   assertDetected
@@ -682,14 +675,6 @@ testTestPackGBWithTests() {
 }
 
 testGlideWithHgDep() {
-    if [ "${IMAGE}" = "heroku/cedar:14" ]; then
-    echo "!!!"
-    echo "!!! Skipping this test on heroku/cedar:14"
-    echo "!!! See: https://www.mercurial-scm.org/wiki/SecureConnections (3.1)"
-    echo "!!!"
-    return 0
-  fi
-
   fixture "glide-with-hg-dep"
 
   assertDetected


### PR DESCRIPTION
cedar-14 is long retired. While here, also update Makefile's default IMAGE from heroku/heroku:16-build (which is on its way out) to heroku/heroku:20-build.