### PR TITLE
bin/test: install patter in a modules-friendly way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Drop cedar-14 from test matrix
 * Remove skipping of tests on cedar-14
 * Update Makefile's default IMAGE to heroku/heroku:20-build
+* Install patter in a Go 1.16+ compatible way
 
 ## v151 (2021-02-01)
 * Add go1.16rc1, use for go1.16

--- a/bin/test
+++ b/bin/test
@@ -44,7 +44,7 @@ else
 fi
 
 # Install our vendored copy of github.com/apg/patter
-GOPATH="${testpack}/lib" GOBIN="${build}/bin" go install github.com/apg/patter
+(cd "${testpack}/lib/src/github.com/apg/patter" && GOPATH="${testpack}/lib" GOBIN="${build}/bin" go install .)
 
 output=$(mktemp)
 

--- a/data.json
+++ b/data.json
@@ -115,6 +115,7 @@
       "go1.11.13.linux-amd64.tar.gz",
       "go1.12.17.linux-amd64.tar.gz",
       "go1.14.2.linux-amd64.tar.gz",
+      "go1.16rc1.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/lib/src/github.com/apg/patter/go.mod
+++ b/lib/src/github.com/apg/patter/go.mod
@@ -1,0 +1,3 @@
+module github.com/apg/patter
+
+go 1.15

--- a/sbin/copy
+++ b/sbin/copy
@@ -31,6 +31,7 @@ ctt bin/test-compile
 ctt lib/common.sh
 ctt lib/common_tools.sh
 ctt lib/src/github.com/apg/patter/main.go
+ctt lib/src/github.com/apg/patter/go.mod
 ctt vendor/concurrency.sh
 ctt CHANGELOG.md
 ctt data.json

--- a/test/fixtures/mod-deps-with-tests-116/.golangci.yml
+++ b/test/fixtures/mod-deps-with-tests-116/.golangci.yml
@@ -1,0 +1,6 @@
+run:
+  deadline: 10m
+  tests: true
+linters:
+  enable-all: true
+  fast: true

--- a/test/fixtures/mod-deps-with-tests-116/Procfile
+++ b/test/fixtures/mod-deps-with-tests-116/Procfile
@@ -1,0 +1,1 @@
+web: fixture

--- a/test/fixtures/mod-deps-with-tests-116/go.mod
+++ b/test/fixtures/mod-deps-with-tests-116/go.mod
@@ -1,0 +1,10 @@
+// +heroku goVersion 1.16rc1
+
+module github.com/heroku/fixture
+
+require (
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2
+)
+
+go 1.16

--- a/test/fixtures/mod-deps-with-tests-116/go.sum
+++ b/test/fixtures/mod-deps-with-tests-116/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
+github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/test/fixtures/mod-deps-with-tests-116/main.go
+++ b/test/fixtures/mod-deps-with-tests-116/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	fmt.Println(mux.ErrNotFound)
+}

--- a/test/fixtures/mod-deps-with-tests-116/main_test.go
+++ b/test/fixtures/mod-deps-with-tests-116/main_test.go
@@ -1,0 +1,10 @@
+package main
+
+import "testing"
+
+func Test_BasicTest(t *testing.T) {
+	one := 1
+	if one != 1 {
+		t.Fatalf("expected 1 == 1")
+	}
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -47,6 +47,26 @@ github.com/gorilla/mux
   assertCaptured "Running: golangci-lint -v --build-tags heroku run"
 }
 
+testTestPackModulesGolangLintCI116() {
+  fixture "mod-deps-with-tests-116"
+
+  dotest
+  assertCapturedSuccess
+
+  # The other deps are downloaded/installed
+  assertCaptured "
+go: finding github.com/gorilla/mux v1.6.2
+go: finding github.com/gorilla/context v1.1.1
+go: downloading github.com/gorilla/mux v1.6.2
+go: extracting github.com/gorilla/mux v1.6.2
+github.com/gorilla/mux
+"
+  assertCaptured "RUN   Test_BasicTest"
+  assertCaptured "PASS: Test_BasicTest"
+  assertCaptured "/.golangci.{yml,toml,json} detected"
+  assertCaptured "Running: golangci-lint -v --build-tags heroku run"
+}
+
 testModProcfileCreation() {
   fixture "mod-cmd-web"
 


### PR DESCRIPTION
Starting with Go 1.16, the method used to install patter won't work
since it's not a module.

To help that, add a go.mod and change how `go install` is invoked to a
way that works with Go 1.16 and beyond while still working with
previous versions.

For #446 