### PR TITLE
bump gitlabci-lint version to 1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Bump golangci-lint to v1.38.0
 
 ## v153 (2021-03-11)
 * Add go1.16.1, use for go1.16
@@ -652,3 +653,4 @@
 ## v12 (2015-06-29)
 
 * [GOPATH naming changed & update godep](https://github.com/heroku/heroku-buildpack-go/pull/82)
+

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -24,5 +24,5 @@ if [ -f "${build}/.golangci.yml" -o -f "${build}/.golangci.toml" -o -f "${build}
     step "/.golangci.{yml,toml,json} detected"
     tmp="$(mktemp -d)"
     mkdir -p "${build}/.heroku/golangci/bin"
-    ensureFile "golangci-lint-1.20.0-linux-amd64.tar.gz" "${tmp}" "tar -C ${build}/.heroku/golangci/bin --strip-components=1 -zxf"
+    ensureFile "golangci-lint-1.38.0-linux-amd64.tar.gz" "${tmp}" "tar -C ${build}/.heroku/golangci/bin --strip-components=1 -zxf"
 fi

--- a/data.json
+++ b/data.json
@@ -121,7 +121,7 @@
       "go1.7.6.linux-amd64.tar.gz",
       "go1.8.3.linux-amd64.tar.gz",
       "godep_linux_amd64",
-      "golangci-lint-1.20.0-linux-amd64.tar.gz",
+      "golangci-lint-1.38.0-linux-amd64.tar.gz",
       "govendor_linux_amd64",
       "jq-linux64",
       "mercurial-3.9.tar.gz",

--- a/files.json
+++ b/files.json
@@ -708,13 +708,9 @@
     "SHA": "4f0b1a01461f2a1892c8065989b8561a88a1c1f09e2a36f01042cd759ea1858c",
     "URL": "https://github.com/tools/godep/releases/download/v75/godep_linux_amd64"
   },
-  "golangci-lint-1.16.0-linux-amd64.tar.gz": {
-    "SHA": "5343fc3ffcbb9910925f4047ec3c9f2e9623dd56a72a17ac76fb2886abc0976b",
-    "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.16.0/golangci-lint-1.16.0-linux-amd64.tar.gz"
-  },
-  "golangci-lint-1.20.0-linux-amd64.tar.gz": {
-    "SHA": "5a638cba74fbfb6e11b9dce38e8caf3f18e998b6548118116d631ebcae3ebac5",
-    "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.20.0/golangci-lint-1.20.0-linux-amd64.tar.gz"
+  "golangci-lint-1.38.0-linux-amd64.tar.gz": {
+    "SHA": "97be8342ac9870bee003904bd8de25c0f3169c6b6238a013d6d6862efa5af992",
+    "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.38.0/golangci-lint-1.38.0-linux-amd64.tar.gz"
   },
   "govendor_linux_amd64": {
     "LocalName": "govendor",


### PR DESCRIPTION
When users use newer golngci config on local machines, running the old version on Heroku may fail with this kind of errors
```
-----> Running: golangci-lint -v --build-tags heroku run
level=info msg="[config_reader] Config search paths: [./ /app /]"
level=info msg="[config_reader] Used config file .golangci.yml"
level=error msg="Running error: no such linter \"gomnd\""
level=info msg="Memory: 2 samples, avg is 68.4MB, max is 68.4MB"
level=info msg="Execution took 15.484269ms"
```

So it's important to keep latest version of golangci-lint, or even [allow specifying the golangci-lint version](https://github.com/heroku/heroku-buildpack-go/issues/436) since it can be downloaded directly.