### PR TITLE
Set xtrace if $BUILDPACK_XTRACE set

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,8 @@
 
 set -eo pipefail
 
+[ "$BUILDPACK_XTRACE" ] && set -o xtrace
+
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)


### PR DESCRIPTION
For debugging or for folks who are curious about how the buildpack works.

Similar implementation here: https://github.com/heroku/heroku-buildpack-python/pull/226