### PR TITLE
Drop Heroku-16 from CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     parameters:
       stack-version:
         type: enum
-        enum: ["16", "18", "20"]
+        enum: ["18", "20"]
     docker:
       - image: heroku/heroku:<< parameters.stack-version >>-build
     steps:
@@ -23,4 +23,4 @@ workflows:
       - test-heroku:
           matrix:
             parameters:
-              stack-version: ["16", "18", "20"]
+              stack-version: ["18", "20"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Drop Heroku-16 from CI test matrix
 
 ## v153 (2021-03-11)
 * Add go1.16.1, use for go1.16


### PR DESCRIPTION
The Heroku-16 stack reached end-of-life on May 1st, 2021, and from June 1st, 2021, builds will be disabled:
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

This removes support for testing against Heroku-16 in CI.

This change is non-breaking as it only affects development (hence why it's landing a few days early), however a changelog entry has been added regardless, for improved visibility into the support status of the stack.

Closes GUS-W-9329693.