### PR TITLE
Add Heroku-22 to the CI test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     parameters:
       stack-version:
         type: enum
-        enum: ["18", "20"]
+        enum: ["18", "20", "22"]
     docker:
       - image: heroku/heroku:<< parameters.stack-version >>-build
     steps:
@@ -23,4 +23,4 @@ workflows:
       - test-heroku:
           matrix:
             parameters:
-              stack-version: ["18", "20"]
+              stack-version: ["18", "20", "22"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add Heroku-22 to the Circle CI test matrix.
 
 ## v161 (2022-03-15)
 * Add go1.15.11


### PR DESCRIPTION
The Go binaries are not stack-specific, so no code/binary changes are needed for Heroku-22 - only testing it in CI.

This buildpack uses Docker tests rather than Hatchet tests, so the new stack can be added to the CI test matrix even before it's possible to create new Heroku-22 apps on the platform.

GUS-W-10344045.