### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Switch to the recommended regional S3 domain instead of the global one
 
 ## v163 (2022-06-09)
 * Use the go version in `go.mod` if no `+heroku` comment is found (#378/#411)

--- a/files.json
+++ b/files.json
@@ -880,7 +880,7 @@
   },
   "stdlib.sh.v8": {
     "SHA": "48b1c663ceda9e93a42fa2ed610fbdd12f9801abd55c317990b30ec75dc3d715",
-    "URL": "https://lang-common.s3.amazonaws.com/buildpack-stdlib/v8/stdlib.sh"
+    "URL": "https://lang-common.s3.us-east-1.amazonaws.com/buildpack-stdlib/v8/stdlib.sh"
   },
   "tq-v0.4-linux-amd64": {
     "LocalName": "tq",

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -19,7 +19,7 @@ NC='\033[0m' # No Color
 CURL="curl -s -L --retry 15 --retry-delay 2" # retry for up to 30 seconds
 
 if [ -z "${GO_BUCKET_URL}" ]; then
-    BucketURL="https://heroku-golang-prod.s3.amazonaws.com"
+    BucketURL="https://heroku-golang-prod.s3.us-east-1.amazonaws.com"
 else
     BucketURL="${GO_BUCKET_URL}"
 fi


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.