### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Adjust curl retry and connection timeout handling
 * Switch to the recommended regional S3 domain instead of the global one
 
 ## v163 (2022-06-09)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -16,7 +16,7 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m' # No Color
-CURL="curl -s -L --retry 15 --retry-delay 2" # retry for up to 30 seconds
+CURL="curl -s -L --fail --retry 15 --retry-delay 2 --retry-connrefused --connect-timeout 5" # retry for up to 30 seconds
 
 if [ -z "${GO_BUCKET_URL}" ]; then
     BucketURL="https://heroku-golang-prod.s3.us-east-1.amazonaws.com"

--- a/sbin/fetch-test-assets
+++ b/sbin/fetch-test-assets
@@ -40,7 +40,7 @@ for f in $(< "${df}" jq -r '.test.assets[]'); do
         else
             url=$(< "${jf}" jq -r '."'${f}'".URL')
             echo "Fetching ${url}"
-            curl -s -L --retry 15 --retry-delay 2 -o "${f}" "${url}"
+            curl -sS -L --fail --retry 15 --retry-delay 2 --retry-connrefused --connect-timeout 5 -o "${f}" "${url}"
         fi
     fi
     if ! shaMatchesKnown "${jf}" "${f}"; then

--- a/sbin/sync-files.sh
+++ b/sbin/sync-files.sh
@@ -46,7 +46,7 @@ ensureFile() {
 
   if [ ! -e "${file}" ]; then
     url="$(< "${filesJSON}" jq -r '."'${file}'".URL')"
-    curl -s -J -o "${file}" -L --retry 15 --retry-delay 2 ${url} 2>&1
+    curl -sS -J -o "${file}" -L --fail --retry 15 --retry-delay 2 --retry-connrefused --connect-timeout 5 ${url} 2>&1
   fi
 
   local knownSHA="$(< "${filesJSON}" jq -r '."'${file}'".SHA' 2>&1)"


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.