### PR TITLE
Release v166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v166 (2022-06-15)
+* Re-release of the changes in v164.
+
+## v165 (2022-06-14)
+* Temporary rollback of the v164 release.
+
 ## v164 (2022-06-14)
 * Adjust curl retry and connection timeout handling
 * Switch to the recommended regional S3 domain instead of the global one


### PR DESCRIPTION
The changes in v164 were temporarily rolled back using the buildpack registry rollback feature, in v165, in order to give another team time to pin their buildpack version. More context in [this Slack thread](https://heroku.slack.com/archives/CCKDFGTL7/p1655211078880609).

Now that they have, we're releasing the same changes again as v166.

GUS-W-11283397.