### PR TITLE
Fixup release version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## v167 (2022-09-08)
+## v168 (2022-09-08)
 * Add go1.19
 * Add go1.19.1
 * Add go1.18.6
@@ -19,7 +19,7 @@
 * Adjust curl retry and connection timeout handling
 * Switch to the recommended regional S3 domain instead of the global one
 
-## v163 (2022-06-09)
+## v163 (2022-06-09), v167 (published by mistake 2022-09-08)
 * Use the go version in `go.mod` if no `+heroku` comment is found (#378/#411)
 * Add go1.18.3
 * go1.18 defaults to 1.18.3

--- a/sbin/publish.sh
+++ b/sbin/publish.sh
@@ -1,24 +1,26 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 BP_NAME=${1:-"heroku/go"}
 
 curVersion=$(heroku buildpacks:versions "$BP_NAME" | awk 'FNR == 3 { print $1 }')
 newVersion="v$((curVersion + 1))"
 
-read -r -p "Deploy as version: $newVersion [y/n]? " choice
+read -p "Deploy as version: $newVersion [y/n]? " choice
 case "$choice" in
   y|Y ) echo "";;
   n|N ) exit 0;;
   * ) exit 1;;
 esac
 
+git fetch origin
 originMain=$(git rev-parse origin/main)
 echo "Tagging commit $originMain with $newVersion... "
 git tag "$newVersion" "${originMain:?}"
 git push origin refs/tags/$newVersion
 
+echo -e "\nPublishing to the buildpack registry..."
 heroku buildpacks:publish "$BP_NAME" "$newVersion"
-
-echo "Done."
+echo
+heroku buildpacks:versions "${BP_NAME}" | head -n 3


### PR DESCRIPTION
`v167` was mistakenly tagged in GitHub during the publication process of `v163`. When `167` was published to the buildpack registry, it ended up pointing to `v163` code. I've republished the latest code (including go1.19 from #496) to the registry, where it is now known as `168`. Once this is merged, I'll fix the git tags to match this changelog and the buildpack registry.

This also updates the publish script to match that of heroku/heroku-buildpacks-python, which includes a `git fetch` to prevent problems like these.