### PR TITLE
Convert heroku/heroku-buildpack-go to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: heroku/heroku-buildpack-go/ci
+on:
+  push:
+jobs:
+  test-heroku:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: heroku/heroku:${{ matrix.stack-version }}-build
+    strategy:
+      matrix:
+        stack-version:
+        - '18'
+        - '20'
+        - '22'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch test assets
+      run: make test-assets
+    - name: Run shunit2 tests
+      run: test/run.sh


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-go) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/heroku-buildpack-go/ci
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest