### PR TITLE
Add changelog entry for v169

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+
+## v169 (2022-11-09)
 * Add go1.19.2, and go1.19.3
 * Add go1.18.4, go1.18.5, go1.18.7, and go1.18.8
 * Add go1.17.11, go1.17.12, and go1.17.13


### PR DESCRIPTION
v169 has already been released: https://github.com/heroku/heroku-buildpack-go/releases/tag/v169. This updates the changelog to reflect that release.