### PR TITLE
Prepare release v171

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+
+### v171 (2023-02-06)
 * Add go1.20, use for go1.20 and go1.20.0
 
 ### v170 (2023-01-23)


### PR DESCRIPTION
This will ship go1.20 under the v171 release. Go 1.20 was added in #507.

https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001KlzR0YAJ