### PR TITLE
Add support for Golang 1.20.2 and make it default for 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Go Buildpack Changelog
 
 ## Unreleased
-* Add go1.20.2
+
+### v172 (2023-03-23)
+* Add go1.20.1 and go1.20.2
+* Add go1.19.6 and go1.19.7
 * go1.20 defaults to 1.20.2
+* go1.19 defaults to 1.19.7
 
 ### v171 (2023-02-06)
 * Add go1.20, use for go1.20 and go1.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add go1.20.2
+* go1.20 defaults to 1.20.2
 
 ### v171 (2023-02-06)
 * Add go1.20, use for go1.20 and go1.20.0

--- a/data.json
+++ b/data.json
@@ -2,11 +2,10 @@
   "Go": {
     "DefaultVersion": "go1.12.17",
     "VersionExpansion": {
-      "go1.20.2": "go1.20.2",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.2",
       "go1.19.0": "go1.19",
-      "go1.19": "go1.19.5",
+      "go1.19": "go1.19.7",
       "go1.18.0": "go1.18",
       "go1.18": "go1.18.10",
       "go1.17.0": "go1.17",
@@ -130,8 +129,7 @@
       "go1.16.15.linux-amd64.tar.gz",
       "go1.17.13.linux-amd64.tar.gz",
       "go1.18.10.linux-amd64.tar.gz",
-      "go1.19.5.linux-amd64.tar.gz",
-      "go1.20.linux-amd64.tar.gz",
+      "go1.19.7.linux-amd64.tar.gz",
       "go1.20.2.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",

--- a/data.json
+++ b/data.json
@@ -2,8 +2,9 @@
   "Go": {
     "DefaultVersion": "go1.12.17",
     "VersionExpansion": {
+      "go1.20.2": "go1.20.2",
       "go1.20.0": "go1.20",
-      "go1.20": "go1.20",
+      "go1.20": "go1.20.2",
       "go1.19.0": "go1.19",
       "go1.19": "go1.19.5",
       "go1.18.0": "go1.18",
@@ -131,6 +132,7 @@
       "go1.18.10.linux-amd64.tar.gz",
       "go1.19.5.linux-amd64.tar.gz",
       "go1.20.linux-amd64.tar.gz",
+      "go1.20.2.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -699,6 +699,14 @@
     "SHA": "36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95",
     "URL": "https://dl.google.com/go/go1.19.5.linux-amd64.tar.gz"
   },
+  "go1.19.6.linux-amd64.tar.gz": {
+    "SHA": "e3410c676ced327aec928303fef11385702a5562fd19d9a1750d5a2979763c3d",
+    "URL": "https://dl.google.com/go/go1.19.6.linux-amd64.tar.gz"
+  },
+  "go1.19.7.linux-amd64.tar.gz": {
+    "SHA": "7a75720c9b066ae1750f6bcc7052aba70fa3813f4223199ee2a2315fd3eb533d",
+    "URL": "https://dl.google.com/go/go1.19.7.linux-amd64.tar.gz"
+  },
   "go1.19.linux-amd64.tar.gz": {
     "SHA": "464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6",
     "URL": "https://dl.google.com/go/go1.19.linux-amd64.tar.gz"
@@ -715,13 +723,17 @@
     "SHA": "1252ca0aa0a96d53c0592fbc4ea9c9ff5c6b588169c92e08d06da9d89d9d91f2",
     "URL": "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/go/go1.2.linux-amd64.tar.gz"
   },
-  "go1.20.linux-amd64.tar.gz": {
-    "SHA": "5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1",
-    "URL": "https://dl.google.com/go/go1.20.linux-amd64.tar.gz"
+  "go1.20.1.linux-amd64.tar.gz": {
+    "SHA": "000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02",
+    "URL": "https://dl.google.com/go/go1.20.1.linux-amd64.tar.gz"
   },
   "go1.20.2.linux-amd64.tar.gz": {
     "SHA": "4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768",
     "URL": "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz"
+  },
+  "go1.20.linux-amd64.tar.gz": {
+    "SHA": "5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1",
+    "URL": "https://dl.google.com/go/go1.20.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",

--- a/files.json
+++ b/files.json
@@ -719,6 +719,10 @@
     "SHA": "5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1",
     "URL": "https://dl.google.com/go/go1.20.linux-amd64.tar.gz"
   },
+  "go1.20.2.linux-amd64.tar.gz": {
+    "SHA": "4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768",
+    "URL": "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz"
+  },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",
     "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz"


### PR DESCRIPTION
New Versions:

* `1.20.2`
* `1.20.1`
* `1.19.6`
* `1.19.7`

Default changes:

* `1.20: 1.20 => 1.20.2`
* `1.19: 1.19.5 => 1.19.7`
