### PR TITLE
Add go 1.20.12 and 1.21.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Go Buildpack Changelog
 
 ## Unreleased
+* Add go1.20.12
+* Add go1.21.5
+* go1.20 defaults to go1.20.12
+* go1.21 defaults to go1.21.45
 
 ## v182 (2023-11-13)
 * Add go1.20.11

--- a/data.json
+++ b/data.json
@@ -2,9 +2,9 @@
   "Go": {
     "DefaultVersion": "go1.12.17",
     "VersionExpansion": {
-      "go1.21": "go1.21.4",
+      "go1.21": "go1.21.5",
       "go1.20.0": "go1.20",
-      "go1.20": "go1.20.11",
+      "go1.20": "go1.20.12",
       "go1.19.0": "go1.19",
       "go1.19": "go1.19.13",
       "go1.18.0": "go1.18",
@@ -131,8 +131,8 @@
       "go1.17.13.linux-amd64.tar.gz",
       "go1.18.10.linux-amd64.tar.gz",
       "go1.19.13.linux-amd64.tar.gz",
-      "go1.20.11.linux-amd64.tar.gz",
-      "go1.21.4.linux-amd64.tar.gz",
+      "go1.20.12.linux-amd64.tar.gz",
+      "go1.21.5.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -759,6 +759,10 @@
     "SHA": "ef79a11aa095a08772d2a69e4f152f897c4e96ee297b0dc20264b7dec2961abe",
     "URL": "https://dl.google.com/go/go1.20.11.linux-amd64.tar.gz"
   },
+  "go1.20.12.linux-amd64.tar.gz": {
+    "SHA": "9c5d48c54dd8b0a3b2ef91b0f92a1190aa01f11d26e98033efa64c46a30bba7b",
+    "URL": "https://dl.google.com/go/go1.20.12.linux-amd64.tar.gz"
+  },
   "go1.20.2.linux-amd64.tar.gz": {
     "SHA": "4eaea32f59cde4dc635fbc42161031d13e1c780b87097f4b4234cfce671f1768",
     "URL": "https://go.dev/dl/go1.20.2.linux-amd64.tar.gz"
@@ -814,6 +818,10 @@
   "go1.21.4.linux-amd64.tar.gz": {
     "SHA": "73cac0215254d0c7d1241fa40837851f3b9a8a742d0b54714cbdfb3feaf8f0af",
     "URL": "https://dl.google.com/go/go1.21.4.linux-amd64.tar.gz"
+  },
+  "go1.21.5.linux-amd64.tar.gz": {
+    "SHA": "e2bc0b3e4b64111ec117295c088bde5f00eeed1567999ff77bc859d7df70078e",
+    "URL": "https://dl.google.com/go/go1.21.5.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",


### PR DESCRIPTION
This PR:

- Adds support for Golang `1.20.12` and `1.21.5`
- Makes them default for their respective release lines