### PR TITLE
Add go1.22rc1, go1.22rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add go1.22rc1, go1.22rc2
 
 ## [v184] - 2024-01-16
 

--- a/files.json
+++ b/files.json
@@ -831,6 +831,14 @@
     "SHA": "3f934f40ac360b9c01f616a9aa1796d227d8b0328bf64cb045c7b8c4ee9caea4",
     "URL": "https://dl.google.com/go/go1.21.6.linux-amd64.tar.gz"
   },
+  "go1.22rc1.linux-amd64.tar.gz": {
+    "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",
+    "URL": "https://dl.google.com/go/go1.22rc1.linux-amd64.tar.gz"
+  },
+  "go1.22rc2.linux-amd64.tar.gz": {
+    "SHA": "f811e7ee8f6dee3d162179229f96a64a467c8c02a5687fac5ceaadcf3948c818",
+    "URL": "https://dl.google.com/go/go1.22rc2.linux-amd64.tar.gz"
+  },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",
     "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz"


### PR DESCRIPTION
This adds the latest Go1.22 release candidates.