### PR TITLE
Use go1.20.14 for DefaultVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [Unreleased]
 
-* Use go1.20.14 as the default
+* Defaults to go1.20.14 when Go version is not specified
+* Defaults to go1.20.14 when bootstrapping Go development releases
 
 ## [v187] - 2024-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Use go1.20.14 as the default
 
 ## [v187] - 2024-02-08
 

--- a/data.json
+++ b/data.json
@@ -1,6 +1,6 @@
 {
   "Go": {
-    "DefaultVersion": "go1.12.17",
+    "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
       "go1.22": "go1.22.0",
       "go1.21": "go1.21.7",

--- a/test/fixtures/dep-golang-migrate/Gopkg.toml
+++ b/test/fixtures/dep-golang-migrate/Gopkg.toml
@@ -1,4 +1,5 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
   additional-tools = ["github.com/golang-migrate/migrate"]
 

--- a/test/fixtures/dep-install-multi/Gopkg.toml
+++ b/test/fixtures/dep-install-multi/Gopkg.toml
@@ -1,4 +1,5 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
   install = ["./a","./b"]
 

--- a/test/fixtures/dep-mattes-migrate/Gopkg.toml
+++ b/test/fixtures/dep-mattes-migrate/Gopkg.toml
@@ -1,4 +1,5 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
   additional-tools = ["github.com/mattes/migrate"]
 

--- a/test/fixtures/dep-no-deps/Gopkg.toml
+++ b/test/fixtures/dep-no-deps/Gopkg.toml
@@ -1,4 +1,5 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
 
 # Gopkg.toml example

--- a/test/fixtures/dep-no-ensure/Gopkg.toml
+++ b/test/fixtures/dep-no-ensure/Gopkg.toml
@@ -1,4 +1,5 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
   ensure = "false"
 

--- a/test/fixtures/dep-with-dep-pruned/Gopkg.toml
+++ b/test/fixtures/dep-with-dep-pruned/Gopkg.toml
@@ -1,6 +1,7 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
-  
+
 # Gopkg.toml example
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md

--- a/test/fixtures/dep-with-dep/Gopkg.toml
+++ b/test/fixtures/dep-with-dep/Gopkg.toml
@@ -1,6 +1,7 @@
 [metadata.heroku]
+  go-version = "go1.12"
   root-package = "github.com/heroku/fixture"
-  
+
 # Gopkg.toml example
 #
 # Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md

--- a/test/fixtures/godep-devel-go/Godeps/Godeps.json
+++ b/test/fixtures/godep-devel-go/Godeps/Godeps.json
@@ -1,5 +1,0 @@
-{
-    "GoVersion": "devel-15f7a66",
-    "ImportPath": "github.com/heroku/fixture",
-    "Deps": []
-}

--- a/test/fixtures/godep-devel-go/main.go
+++ b/test/fixtures/godep-devel-go/main.go
@@ -1,8 +1,0 @@
-package main
-
-import "fmt"
-import "runtime"
-
-func main() {
-	fmt.Println(runtime.Version())
-}

--- a/test/fixtures/govendor-basic-wo-procfile/vendor/vendor.json
+++ b/test/fixtures/govendor-basic-wo-procfile/vendor/vendor.json
@@ -3,5 +3,8 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-    ]
+	],
+	"heroku": {
+		"goVersion": "go1.12"
+	}
 }

--- a/test/fixtures/govendor-basic/vendor/vendor.json
+++ b/test/fixtures/govendor-basic/vendor/vendor.json
@@ -3,5 +3,8 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-    ]
+	],
+	"heroku": {
+		"goVersion": "go1.12"
+	}
 }

--- a/test/fixtures/govendor-cmd/vendor/vendor.json
+++ b/test/fixtures/govendor-cmd/vendor/vendor.json
@@ -3,8 +3,9 @@
 	"comment": "",
 	"ignore": "test",
 	"heroku": {
-		"install":["./..."]
+		"install":["./..."],
+		"goVersion": "go1.12"
 	},
 	"package": [
-    ]
+	]
 }

--- a/test/fixtures/govendor-excluded/vendor/vendor.json
+++ b/test/fixtures/govendor-excluded/vendor/vendor.json
@@ -9,5 +9,8 @@
 			"revisionTime": "2015-01-10T00:16:55Z"
 		}
 	],
-	"rootPath": "github.com/heroku/fixture"
+	"rootPath": "github.com/heroku/fixture",
+	"heroku": {
+		"goVersion": "go1.12"
+	}
 }

--- a/test/fixtures/govendor-mattes-migrate/vendor/vendor.json
+++ b/test/fixtures/govendor-mattes-migrate/vendor/vendor.json
@@ -3,7 +3,8 @@
 	"ignore": "test",
 	"heroku": {
 		"install":["."],
-		"additionalTools":["github.com/mattes/migrate"]
+		"additionalTools":["github.com/mattes/migrate"],
+		"goVersion": "go1.12"
 	},
 	"package": [],
 	"rootPath": "github.com/heroku/fixture"

--- a/test/fixtures/govendor-with-tests/vendor/vendor.json
+++ b/test/fixtures/govendor-with-tests/vendor/vendor.json
@@ -3,5 +3,8 @@
 	"comment": "",
 	"ignore": "test",
 	"package": [
-    ]
+	],
+	"heroku": {
+		"goVersion": "go1.12"
+	}
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -8,7 +8,7 @@ testModWithBZRDep() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured
+  assertGoInstallCaptured "go1.12.17"
   assertGoInstallOnlyFixturePackageCaptured
 
   assertCapturedExitSuccess
@@ -74,7 +74,7 @@ testModProcfileCreation() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured
+  assertGoInstallCaptured "go1.12.17"
   assertCaptured "Running: go install -v -tags heroku github.com/heroku/fixture/cmd/web
 github.com/heroku/fixture/cmd/other"
 
@@ -128,7 +128,7 @@ testModWithQuotesModule() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured
+  assertGoInstallCaptured "go1.12.17"
   assertGoInstallOnlyFixturePackageCaptured
 
   assertCapturedSuccess
@@ -162,7 +162,7 @@ testModcmdDetection() {
 
   compile
   assertModulesBoilerplateCaptured
-  assertGoInstallCaptured
+  assertGoInstallCaptured "go1.12.17"
   assertCaptured "Detected the following main packages to install:
 github.com/heroku/fixture/cmd/fixture
 github.com/heroku/fixture/cmd/other"

--- a/test/run.sh
+++ b/test/run.sh
@@ -798,6 +798,8 @@ testTestPackGBWithTests() {
 testGlideWithHgDep() {
   fixture "glide-with-hg-dep"
 
+  env "GOVERSION" "go1.12"
+
   assertDetected
 
   compile
@@ -898,6 +900,7 @@ testGlideMassageVendor() {
   fixture "glide-massage-vendor"
 
   env "GO_INSTALL_PACKAGE_SPEC" ". github.com/mattes/migrate"
+  env "GOVERSION" "go1.12"
 
   assertDetected
 
@@ -938,6 +941,8 @@ testGlideMassageVendor() {
 testGlideWithOutDeps() {
   fixture "glide-wo-deps"
 
+  env "GOVERSION" "go1.12"
+
   assertDetected
 
   compile
@@ -953,6 +958,8 @@ testGlideWithOutDeps() {
 testGlideWithDeps() {
   fixture "glide-with-deps"
 
+  env "GOVERSION" "go1.12"
+
   assertDetected
 
   compile
@@ -967,6 +974,8 @@ testGlideWithDeps() {
 
 testGlideBasic() {
   fixture "glide-basic"
+
+  env "GOVERSION" "go1.12"
 
   assertDetected
 
@@ -984,6 +993,7 @@ testGlideBasicWithTools() {
   fixture "glide-basic"
 
   env "GO_INSTALL_TOOLS_IN_IMAGE" "true"
+  env "GOVERSION" "go1.12"
 
   assertDetected
 
@@ -1002,6 +1012,7 @@ testGlideBasicInGOPATH() {
   fixture "glide-basic"
 
   env "GO_SETUP_GOPATH_IN_IMAGE" "true"
+  env "GOVERSION" "go1.12"
 
   assertDetected
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -760,6 +760,8 @@ testTestPackGovendorWithTests() {
 testTestPackGlideWithTests() {
   fixture "glide-with-tests"
 
+  env "GOVERSION" "go1.12"
+
   dotest
   assertCapturedSuccess
   assertCaptured "RUN   TestHello"
@@ -771,6 +773,8 @@ testTestPackGlideWithTests() {
 
 testTestPackGodepWithTests() {
   fixture "godep-with-tests"
+
+  env "GOVERSION" "go1.12"
 
   dotest
   assertCapturedSuccess

--- a/test/run.sh
+++ b/test/run.sh
@@ -1167,24 +1167,6 @@ testGodepCGOBasic() {
   assertCompiledBinaryExists
 }
 
-testGodepDevelGo() {
-  fixture "godep-devel-go"
-
-  assertDetected
-
-  compile
-  assertCaptured "You are using a development build of Go."
-  assertCaptured "Installing bootstrap go"
-  assertCaptured "Downloading development Go version devel-15f7a66"
-  assertCaptured "Compiling development Go version devel-15f7a66"
-  assertCaptured "Installed Go for linux/amd64"
-  assertCaptured "go version devel +15f7a66"
-  assertCapturedSuccess
-  assertCompiledBinaryExists
-  assertCompiledBinaryOutputs "fixture" "devel +15fa66"
-  #assertTrue "Binary has the right value" '[[ "$(${BUILD_DIR}/bin/fixture)" = *"devel +15f7a66"* ]]'
-}
-
 testGodepBinFile() {
   fixture "godep-bin-file"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -734,6 +734,7 @@ testTestPackGBWithTestsSkipBenchmark() {
   fixture "gb-with-tests"
 
   env "GO_TEST_SKIP_BENCHMARK" "nope"
+  env "GOVERSION" "go1.12"
 
   dotest
   assertCapturedSuccess
@@ -782,6 +783,8 @@ testTestPackGodepWithTests() {
 
 testTestPackGBWithTests() {
   fixture "gb-with-tests"
+
+  env "GOVERSION" "go1.12"
 
   dotest
   assertCapturedSuccess
@@ -1221,6 +1224,8 @@ testGodepMalformed() {
 testGBVendor() {
   fixture "gb-vendor"
 
+  env "GOVERSION" "go1.12"
+
   assertDetected
 
   compile
@@ -1235,6 +1240,8 @@ testGBVendor() {
 
 testGBBasic() {
   fixture "gb-basic"
+
+  env "GOVERSION" "go1.12"
 
   assertDetected
 
@@ -1252,10 +1259,12 @@ testGBBasicWithTools() {
   fixture "gb-basic"
 
   env "GO_INSTALL_TOOLS_IN_IMAGE" "true"
+  env "GOVERSION" "go1.12"
 
   assertDetected
 
   compile
+
   assertCaptured "Installing go"
   assertCaptured "Installing GB"
   assertCaptured "Running: gb build -tags heroku"

--- a/test/run.sh
+++ b/test/run.sh
@@ -706,6 +706,7 @@ testTestPackGlideWithTestsSkipBenchmark() {
   fixture "glide-with-tests"
 
   env "GO_TEST_SKIP_BENCHMARK" "nope"
+  env "GOVERSION" "go1.12"
 
   dotest
   assertCapturedSuccess


### PR DESCRIPTION
I noticed when trying to deploy a Go app via dokku using Go version `devel-a10e42f` (which is is https://github.com/golang/go/releases/tag/go1.22.0) I received the following error using the most recent https://github.com/heroku/heroku-buildpack-go/ (0210495):

**Before**

```sh
$ make deploy
--snip--
-----> New Go Version, clearing old cache
-----> Installing bootstrap go1.12.17
-----> Fetching go1.12.17.linux-amd64.tar.gz... done
-----> Downloading development Go version devel-a10e42f... done
-----> Compiling development Go version devel-a10e42f
       Building Go cmd/dist using /cache/go1.12.17/go. (go1.12.17 linux/amd64)
       can't load package: package ./cmd/dist: found packages main (build.go) and building_Go_requires_Go_1_20_6_or_later (notgo120.go) in /cache/devel-a10e42f/go/src/cmd/dist
```

**After**

```sh
$ dokku buildpacks:set https://github.com/ashmckenzie/heroku-buildpack-go#82e57c6

$ make deploy
--snip--
-----> New Go Version, clearing old cache
-----> Installing bootstrap go1.20.13
-----> Fetching go1.20.13.linux-amd64.tar.gz... done
-----> Downloading development Go version devel-a10e42f... done
-----> Compiling development Go version devel-a10e42f
       Building Go cmd/dist using /cache/go1.20.13/go. (go1.20.13 linux/amd64)
       Building Go toolchain1 using /cache/go1.20.13/go.
       Building Go bootstrap cmd/go (go_bootstrap) using Go toolchain1.
       Building Go toolchain2 using go_bootstrap and Go toolchain1.
       Building Go toolchain3 using go_bootstrap and Go toolchain2.
       Building packages and commands for linux/amd64.
---
       Installed Go for linux/amd64 in /cache/devel-a10e42f/go
       Installed commands in /cache/devel-a10e42f/go/bin
       *** You need to add /cache/devel-a10e42f/go/bin to your PATH.
       go version devel +a10e42f Wed Feb 08:14:33 2024 +0000 linux/amd64
```

Increasing `DefaultVersion` to `go1.20.13` as recommended then allows custom Go versions to be built.