### PR TITLE
Added go 1.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Add go1.22.0
+* Use go1.22.0 for go1.22
 
 ## [v185] - 2024-02-06
 

--- a/data.json
+++ b/data.json
@@ -2,6 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.12.17",
     "VersionExpansion": {
+      "go1.22.0": "go1.22.0",
+      "go1.22": "go1.22.0",
       "go1.21": "go1.21.6",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.13",
@@ -133,6 +135,7 @@
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.13.linux-amd64.tar.gz",
       "go1.21.6.linux-amd64.tar.gz",
+      "go1.22.0.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/data.json
+++ b/data.json
@@ -2,7 +2,6 @@
   "Go": {
     "DefaultVersion": "go1.12.17",
     "VersionExpansion": {
-      "go1.22.0": "go1.22.0",
       "go1.22": "go1.22.0",
       "go1.21": "go1.21.6",
       "go1.20.0": "go1.20",

--- a/files.json
+++ b/files.json
@@ -831,6 +831,10 @@
     "SHA": "3f934f40ac360b9c01f616a9aa1796d227d8b0328bf64cb045c7b8c4ee9caea4",
     "URL": "https://dl.google.com/go/go1.21.6.linux-amd64.tar.gz"
   },
+  "go1.22.0.linux-amd64.tar.gz": {
+    "SHA": "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",
+    "URL": "https://dl.google.com/go/go1.22.0.linux-amd64.tar.gz"
+  },
   "go1.22rc1.linux-amd64.tar.gz": {
     "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",
     "URL": "https://dl.google.com/go/go1.22rc1.linux-amd64.tar.gz"
@@ -838,10 +842,6 @@
   "go1.22rc2.linux-amd64.tar.gz": {
     "SHA": "f811e7ee8f6dee3d162179229f96a64a467c8c02a5687fac5ceaadcf3948c818",
     "URL": "https://dl.google.com/go/go1.22rc2.linux-amd64.tar.gz"
-  },
-  "go1.22.0.linux-amd64.tar.gz": {
-    "SHA": "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",
-    "URL": "https://dl.google.com/go/go1.22.0.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",

--- a/files.json
+++ b/files.json
@@ -839,6 +839,10 @@
     "SHA": "f811e7ee8f6dee3d162179229f96a64a467c8c02a5687fac5ceaadcf3948c818",
     "URL": "https://dl.google.com/go/go1.22rc2.linux-amd64.tar.gz"
   },
+  "go1.22.0.linux-amd64.tar.gz": {
+    "SHA": "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",
+    "URL": "https://dl.google.com/go/go1.22.0.linux-amd64.tar.gz"
+  },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",
     "URL": "https://storage.googleapis.com/golang/go1.3.1.linux-amd64.tar.gz"


### PR DESCRIPTION
This PR adds support for go 1.22.0.
Closes https://github.com/heroku/heroku-buildpack-go/issues/541