### PR TITLE
Add go1.21.1, go1.20.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Add go1.22.1
+* Add go1.21.8
+* go1.22 defaults to go1.22.1
+* go1.21 defaults to go1.21.8
 
 ## [v188] - 2024-02-28
 

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.22": "go1.22.0",
-      "go1.21": "go1.21.7",
+      "go1.22": "go1.22.1",
+      "go1.21": "go1.21.8",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.14",
       "go1.19.0": "go1.19",
@@ -133,8 +133,8 @@
       "go1.18.10.linux-amd64.tar.gz",
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.14.linux-amd64.tar.gz",
-      "go1.21.7.linux-amd64.tar.gz",
-      "go1.22.0.linux-amd64.tar.gz",
+      "go1.21.8.linux-amd64.tar.gz",
+      "go1.22.1.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -839,9 +839,17 @@
     "SHA": "13b76a9b2a26823e53062fa841b07087d48ae2ef2936445dc34c4ae03293702c",
     "URL": "https://dl.google.com/go/go1.21.7.linux-amd64.tar.gz"
   },
+  "go1.21.8.linux-amd64.tar.gz": {
+    "SHA": "538b3b143dc7f32b093c8ffe0e050c260b57fc9d57a12c4140a639a8dd2b4e4f",
+    "URL": "https://dl.google.com/go/go1.21.8.linux-amd64.tar.gz"
+  },
   "go1.22.0.linux-amd64.tar.gz": {
     "SHA": "f6c8a87aa03b92c4b0bf3d558e28ea03006eb29db78917daec5cfb6ec1046265",
     "URL": "https://dl.google.com/go/go1.22.0.linux-amd64.tar.gz"
+  },
+  "go1.22.1.linux-amd64.tar.gz": {
+    "SHA": "aab8e15785c997ae20f9c88422ee35d962c4562212bb0f879d052a35c8307c7f",
+    "URL": "https://dl.google.com/go/go1.22.1.linux-amd64.tar.gz"
   },
   "go1.22rc1.linux-amd64.tar.gz": {
     "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",


### PR DESCRIPTION
This updates the go inventory with the following changes:

* Add go1.22.1
* Add go1.21.8
* go1.22 defaults to go1.22.1
* go1.21 defaults to go1.21.8