### PR TITLE
Add support for heroku-24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         stack-version: ["20", "22", "24"]
     container:
       image: heroku/heroku:${{ matrix.stack-version }}-build
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        stack-version: ["20", "22"]
+        stack-version: ["20", "22", "24"]
     container:
       image: heroku/heroku:${{ matrix.stack-version }}-build
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased]
 
+* Add support for heroku-24
 * Drop support for installing bzr-hosted dependencies directly; bzr-hosted
-  dependencies may still be installed via `GOPROXY`
 
 ## [v190] - 2024-04-05
 


### PR DESCRIPTION
This adds heroku-24 to the test matrix and enables heroku-24 support in this buildpack.