### PR TITLE
Add go1.22.4 and go1.22.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v192] - 2024-06-04
+
 * Add go1.22.4
 * Add go1.21.11
 * go1.22 defaults to go1.22.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Add go1.22.4
+* Add go1.21.11
+* go1.22 defaults to go1.22.4
+* go1.21 defaults to go1.21.11
 
 ## [v191] - 2024-05-07
 

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.22": "go1.22.3",
-      "go1.21": "go1.21.10",
+      "go1.22": "go1.22.4",
+      "go1.21": "go1.21.11",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.14",
       "go1.19.0": "go1.19",
@@ -130,8 +130,8 @@
       "go1.18.10.linux-amd64.tar.gz",
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.14.linux-amd64.tar.gz",
-      "go1.21.10.linux-amd64.tar.gz",
-      "go1.22.3.linux-amd64.tar.gz",
+      "go1.21.11.linux-amd64.tar.gz",
+      "go1.22.4.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -815,6 +815,10 @@
     "SHA": "e330e5d977bf4f3bdc157bc46cf41afa5b13d66c914e12fd6b694ccda65fcf92",
     "URL": "https://dl.google.com/go/go1.21.10.linux-amd64.tar.gz"
   },
+  "go1.21.11.linux-amd64.tar.gz": {
+    "SHA": "54a87a9325155b98c85bc04dc50298ddd682489eb47f486f2e6cb0707554abf0",
+    "URL": "https://dl.google.com/go/go1.21.11.linux-amd64.tar.gz"
+  },
   "go1.21.2.linux-amd64.tar.gz": {
     "SHA": "f5414a770e5e11c6e9674d4cd4dd1f4f630e176d1828d3427ea8ca4211eee90d",
     "URL": "https://dl.google.com/go/go1.21.2.linux-amd64.tar.gz"
@@ -862,6 +866,10 @@
   "go1.22.3.linux-amd64.tar.gz": {
     "SHA": "8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36",
     "URL": "https://dl.google.com/go/go1.22.3.linux-amd64.tar.gz"
+  },
+  "go1.22.4.linux-amd64.tar.gz": {
+    "SHA": "ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d",
+    "URL": "https://dl.google.com/go/go1.22.4.linux-amd64.tar.gz"
   },
   "go1.22rc1.linux-amd64.tar.gz": {
     "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",


### PR DESCRIPTION
This adds go1.22.4 and go1.22.11, and makes them the default for their respective lines. It also tags the v192 release which will contain only these new versions.