### PR TITLE
Source GOFLAGS from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+* Source GOFLAGS from the environment
+
 ## [v192] - 2024-06-04
 
 * Add go1.22.4

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -212,6 +212,7 @@ loadEnvDir() {
     envFlags+=("GO_LINKER_SYMBOL")
     envFlags+=("GO_LINKER_VALUE")
     envFlags+=("GO15VENDOREXPERIMENT")
+    envFlags+=("GOFLAGS")
     envFlags+=("GOPROXY")
     envFlags+=("GOPRIVATE")
     envFlags+=("GONOPROXY")


### PR DESCRIPTION
This allows users to customize their builds a bit more, and do things like `heroku config:set GOFLAGS="-pgo=/tmp/profile.pgo"` so that PGO may be used.

Fixes #400.