### PR TITLE
Add go1.22.5, go1.21.12; make them the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
+## [v193] - 2024-07-15
+
 * Source GOFLAGS from the environment
+* Add go1.22.5
+* Add go1.21.12
+* go1.22 defaults to go1.22.5
+* go1.21 defaults to go1.22.12
 
 ## [v192] - 2024-06-04
 

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.22": "go1.22.4",
-      "go1.21": "go1.21.11",
+      "go1.22": "go1.22.5",
+      "go1.21": "go1.21.12",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.14",
       "go1.19.0": "go1.19",
@@ -130,8 +130,8 @@
       "go1.18.10.linux-amd64.tar.gz",
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.14.linux-amd64.tar.gz",
-      "go1.21.11.linux-amd64.tar.gz",
-      "go1.22.4.linux-amd64.tar.gz",
+      "go1.21.12.linux-amd64.tar.gz",
+      "go1.22.5.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -819,6 +819,10 @@
     "SHA": "54a87a9325155b98c85bc04dc50298ddd682489eb47f486f2e6cb0707554abf0",
     "URL": "https://dl.google.com/go/go1.21.11.linux-amd64.tar.gz"
   },
+  "go1.21.12.linux-amd64.tar.gz": {
+    "SHA": "121ab58632787e18ae0caa8ae285b581f9470d0f6b3defde9e1600e211f583c5",
+    "URL": "https://dl.google.com/go/go1.21.12.linux-amd64.tar.gz"
+  },
   "go1.21.2.linux-amd64.tar.gz": {
     "SHA": "f5414a770e5e11c6e9674d4cd4dd1f4f630e176d1828d3427ea8ca4211eee90d",
     "URL": "https://dl.google.com/go/go1.21.2.linux-amd64.tar.gz"
@@ -870,6 +874,10 @@
   "go1.22.4.linux-amd64.tar.gz": {
     "SHA": "ba79d4526102575196273416239cca418a651e049c2b099f3159db85e7bade7d",
     "URL": "https://dl.google.com/go/go1.22.4.linux-amd64.tar.gz"
+  },
+  "go1.22.5.linux-amd64.tar.gz": {
+    "SHA": "904b924d435eaea086515bc63235b192ea441bd8c9b198c507e85009e6e4c7f0",
+    "URL": "https://dl.google.com/go/go1.22.5.linux-amd64.tar.gz"
   },
   "go1.22rc1.linux-amd64.tar.gz": {
     "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",


### PR DESCRIPTION
This adds go1.22.5 and go1.21.12, and makes them the default for their respective lines. It also tags the v193 release which will contain only these new versions.