### PR TITLE
Add deprecation notices for dep, gb, glide, godep, govendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Deprecate support for unmaintained dependency managers: `dep`, `gb`, `glide`, `godep` and `govendor`. Support for these dependency managers will be removed on March 1, 2025. Apps using these dependency managers should migrate to Go modules as soon as possible. Learn more about using Go modules on Heroku [here](https://devcenter.heroku.com/articles/go-modules).
 
 ## [v195] - 2024-08-13
 

--- a/bin/compile
+++ b/bin/compile
@@ -352,6 +352,14 @@ warnPackageSpecOverride() {
     fi
 }
 
+warnDeprecatedTool() {
+    local tool=$1
+    warn "This application is using ${tool}, but ${tool} is no longer maintained."
+    warn "${tool} support on Heroku is deprecated and will be removed on March 1, 2025."
+    warn "Please migrate to Go modules. Learn more about Go modules on Heroku here: https://devcenter.heroku.com/articles/go-modules."
+}
+
+
 # Sets up GOPATH (and posibly other GO* env vars) and returns the location of
 # the source code as $src. The output of this function is meant to be eval'd'
 setupGOPATH() {
@@ -706,6 +714,11 @@ fi
 
 if needConcurrency ${ver}; then
     cp $buildpack/vendor/concurrency.sh $build/.profile.d/
+fi
+
+# dep, gb, glide, godep, govendor are all unmaintained.
+if [ "${TOOL}" != "gomodules" ]; then
+    warnDeprecatedTool "$TOOL"
 fi
 
 t="${build}/.heroku/go"

--- a/bin/compile
+++ b/bin/compile
@@ -359,7 +359,6 @@ warnDeprecatedTool() {
     warn "Please migrate to Go modules. Learn more about Go modules on Heroku here: https://devcenter.heroku.com/articles/go-modules."
 }
 
-
 # Sets up GOPATH (and posibly other GO* env vars) and returns the location of
 # the source code as $src. The output of this function is meant to be eval'd'
 setupGOPATH() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -1382,6 +1382,7 @@ testGovendorBasic() {
   assertCaptured "Installing package '.' (default)"
   assertCaptured "github.com/heroku/fixture"
   assertCaptured "This application is using govendor, but govendor is no longer maintained."
+  
   assertCapturedSuccess
   assertCompiledBinaryExists
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -635,6 +635,8 @@ testDepGoVersion() {
   assertCaptured "Fetching any unsaved dependencies (dep ensure)"
   assertCaptured "Running: go install -v -tags heroku ."
   assertCaptured "github.com/heroku/fixture"
+  assertCaptured "This application is using dep, but dep is no longer maintained."
+
   assertCapturedSuccess
   assertCompiledBinaryExists
 }
@@ -867,6 +869,8 @@ testGodepBasicGo14WithGOVERSIONOverride() {
   compile
   assertCaptured "Installing go1.6"
   assertCaptured "Using \$GOVERSION override."
+  assertCaptured "This application is using godep, but godep is no longer maintained."
+
   assertCapturedSuccess
   assertCompiledBinaryExists
   assertBuildDirFileDoesNotExist ".profile.d/concurrency.sh"
@@ -975,6 +979,8 @@ testGlideBasic() {
   assertCaptured "Fetching any unsaved dependencies (glide install)"
   assertCaptured "Running: go install -v -tags heroku ."
   assertCaptured "github.com/heroku/fixture"
+  assertCaptured "This application is using glide, but glide is no longer maintained."
+
   assertCapturedSuccess
   assertCompiledBinaryExists
 }
@@ -1234,6 +1240,8 @@ testGBBasic() {
   assertCaptured "Running: gb build -tags heroku"
   assertCaptured "cmd/fixture"
   assertCaptured "Post Compile Cleanup"
+  assertCaptured "This application is using gb, but gb is no longer maintained."
+
   assertCapturedSuccess
   assertCompiledBinaryExists
 }
@@ -1373,6 +1381,7 @@ testGovendorBasic() {
   assertCaptured "Running: go install -v -tags heroku ."
   assertCaptured "Installing package '.' (default)"
   assertCaptured "github.com/heroku/fixture"
+  assertCaptured "This application is using govendor, but govendor is no longer maintained."
   assertCapturedSuccess
   assertCompiledBinaryExists
 }


### PR DESCRIPTION
The Go language dependency managers [dep](https://github.com/golang/dep), [gb](https://github.com/constabulary/gb), [glide](https://github.com/Masterminds/glide), [godep](https://github.com/tools/godep), and [govendor](https://github.com/kardianos/govendor) are no longer maintained. Therefore, Heroku is deprecating support for these dependency managers.

On March 1, 2025, Heroku will no longer support these dependency managers. At that time, builds on Heroku using dep, gb, glide, godep, or govendor will fail.

If you have an app using dep, gb, glide, godep, or govendor, please migrate to Go modules as soon as possible. Learn more about using Go modules on Heroku [here](https://devcenter.heroku.com/articles/go-modules).

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000020AQREYA4/view)