### PR TITLE
Support wwwauth[] key in git credential helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add support for wwwauth[] git credential arguments
 
 ## [v195] - 2024-08-13
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -270,6 +270,9 @@ setGitCredHelper() {
                     password)
                         password="${value}"
                     ;;
+                    wwwauth[])
+                        :
+                    ;;
                     *)
                         echo "Unsupported key: ${key}=${value}" >&2
                         exit 1


### PR DESCRIPTION
Developers using Heroku-24 and `GO_GIT_CRED_*` are seeing errors in their build logs like these:

```
Unsupported key: wwwauth[]=Basic realm
```

The `wwwauth[]` key/value pair is a new addition to the git credential API here: https://github.com/git/git/commit/5f2117b24f568ecc789c677748d70ccd538b16ba. It was included in git versions 2.41.0 and later. Heroku-22 and prior didn't have this issue, since it uses git 2.34.1. Heroku-24 is using git 2.43.0, so the issue manifests there.

The key and values are informational only according to this: https://github.com/git/git/blob/master/Documentation/git-credential.txt#L241-L250.

This PR adds a condition to ignore `wwwauth[]`.
