### PR TITLE
Add go1.23.1 and go1.22.7 as new defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## [Unreleased]
 
+* Add go1.23.1
+* Add go1.22.7
+* go1.23 defaults to 1.23.1
+* go1.22 defaults to 1.22.7
 
 ## [v196] - 2024-09-03
 
-* Deprecate support for unmaintained dependency managers: `dep`, `gb`, `glide`, `godep` and `govendor`.  
+* Deprecate support for unmaintained dependency managers: `dep`, `gb`, `glide`, `godep` and `govendor`.
   Support for these dependency managers will be removed on March 1, 2025.
-  Apps using these dependency managers should migrate to Go modules as soon as possible. 
+  Apps using these dependency managers should migrate to Go modules as soon as possible.
   Learn more about using Go modules on Heroku [here](https://devcenter.heroku.com/articles/go-modules).
 * Add support for wwwauth[] git credential arguments
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v197] - 2024-09-05
+
 * Add go1.23.1
 * Add go1.22.7
 * go1.23 defaults to 1.23.1

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.23": "go1.23.0",
-      "go1.22": "go1.22.6",
+      "go1.23": "go1.23.1",
+      "go1.22": "go1.22.7",
       "go1.21": "go1.21.13",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.14",
@@ -132,8 +132,8 @@
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.14.linux-amd64.tar.gz",
       "go1.21.13.linux-amd64.tar.gz",
-      "go1.22.6.linux-amd64.tar.gz",
-      "go1.23.0.linux-amd64.tar.gz",
+      "go1.22.7.linux-amd64.tar.gz",
+      "go1.23.1.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -887,6 +887,10 @@
     "SHA": "999805bed7d9039ec3da1a53bfbcafc13e367da52aa823cb60b68ba22d44c616",
     "URL": "https://dl.google.com/go/go1.22.6.linux-amd64.tar.gz"
   },
+  "go1.22.7.linux-amd64.tar.gz": {
+    "SHA": "fc5d49b7a5035f1f1b265c17aa86e9819e6dc9af8260ad61430ee7fbe27881bb",
+    "URL": "https://dl.google.com/go/go1.22.7.linux-amd64.tar.gz"
+  },
   "go1.22rc1.linux-amd64.tar.gz": {
     "SHA": "fbe9d0585b9322d44008f6baf78b391b22f64294338c6ce2b9eb6040d6373c52",
     "URL": "https://dl.google.com/go/go1.22rc1.linux-amd64.tar.gz"
@@ -898,6 +902,10 @@
   "go1.23.0.linux-amd64.tar.gz": {
     "SHA": "905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3",
     "URL": "https://dl.google.com/go/go1.23.0.linux-amd64.tar.gz"
+  },
+  "go1.23.1.linux-amd64.tar.gz": {
+    "SHA": "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd",
+    "URL": "https://dl.google.com/go/go1.23.1.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",


### PR DESCRIPTION
New [go releases](https://go.dev/doc/devel/release) are available as of 2024-09-05.

* Add go1.23.1
* Add go1.22.7
* go1.23 defaults to 1.23.1
* go1.22 defaults to 1.22.7