### PR TITLE
fix: remove '-tags heroku' passed to CLI to honor '-tags' in GOFLAGS

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -393,8 +393,6 @@ loadEnvDir "${env_dir}"
 setGitCredHelper "${env_dir}"
 trap clearGitCredHelper INT TERM EXIT
 
-FLAGS=(-tags heroku)
-
 determineTool
 
 ver=$(expandVer $ver)


### PR DESCRIPTION
The CLI flag `-tags heroku` forcefully set in the buildpack overrides the tags set in the GOFLAGS environment variable, as per specified in:

https://github.com/golang/go/blob/c96939fbed3d60159dc81ee9ad591de8cfd41168/src/cmd/go/internal/help/helpdoc.go#L525-L531

> Flags listed on the command line are applied after this list and therefore override it.

However, it makes it impossible to set other tags such as `viper_bind_struct` (see https://github.com/spf13/viper/pull/1720) using the standard `GOFLAGS="-tags=viper_bind_struct"`.