### PR TITLE
Update go1.22 and go1.23 defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
+* go1.23 defaults to 1.23.3
+* go1.22 defaults to 1.22.9
 
 ## [v199] - 2024-11-11
 
 * Add go1.23.3
 * Add go1.22.9
-* go1.23 defaults to 1.23.3
-* go1.22 defaults to 1.22.9
 
 ## [v198] - 2024-10-01
 

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.23": "go1.23.2",
-      "go1.22": "go1.22.8",
+      "go1.23": "go1.23.3",
+      "go1.22": "go1.22.9",
       "go1.21": "go1.21.13",
       "go1.20.0": "go1.20",
       "go1.20": "go1.20.14",
@@ -132,8 +132,8 @@
       "go1.19.13.linux-amd64.tar.gz",
       "go1.20.14.linux-amd64.tar.gz",
       "go1.21.13.linux-amd64.tar.gz",
-      "go1.22.8.linux-amd64.tar.gz",
-      "go1.23.2.linux-amd64.tar.gz",
+      "go1.22.9.linux-amd64.tar.gz",
+      "go1.23.3.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",


### PR DESCRIPTION
This default change was missed during #576. Updating the changelog to match reality, too.