### PR TITLE
Add go1.24.2 and go1.23.8 and make them default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [v206] - 2025-04-02
+
+* Add go1.24.2
+* Add go1.23.8
+* go1.24 defaults to 1.24.2
+* go1.23 defaults to 1.23.8
+
 ## [v205] - 2025-03-04
 
 * Add go1.24.1
@@ -1063,7 +1070,8 @@
 
 * [GOPATH naming changed & update godep](https://github.com/heroku/heroku-buildpack-go/pull/82)
 
-[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v205...main
+[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v206...main
+[v206]: https://github.com/heroku/heroku-buildpack-go/compare/v205...v206
 [v205]: https://github.com/heroku/heroku-buildpack-go/compare/v204...v205
 [v204]: https://github.com/heroku/heroku-buildpack-go/compare/v203...v204
 [v203]: https://github.com/heroku/heroku-buildpack-go/compare/v202...v203

--- a/data.json
+++ b/data.json
@@ -2,8 +2,8 @@
   "Go": {
     "DefaultVersion": "go1.20.14",
     "VersionExpansion": {
-      "go1.24": "go1.24.1",
-      "go1.23": "go1.23.7",
+      "go1.24": "go1.24.2",
+      "go1.23": "go1.23.8",
       "go1.22": "go1.22.12",
       "go1.21": "go1.21.13",
       "go1.20.0": "go1.20",
@@ -134,8 +134,8 @@
       "go1.20.14.linux-amd64.tar.gz",
       "go1.21.13.linux-amd64.tar.gz",
       "go1.22.12.linux-amd64.tar.gz",
-      "go1.23.7.linux-amd64.tar.gz",
-      "go1.24.1.linux-amd64.tar.gz",
+      "go1.23.8.linux-amd64.tar.gz",
+      "go1.24.2.linux-amd64.tar.gz",
       "go1.4.3.linux-amd64.tar.gz",
       "go1.6.4.linux-amd64.tar.gz",
       "go1.7.6.linux-amd64.tar.gz",

--- a/files.json
+++ b/files.json
@@ -951,6 +951,10 @@
     "SHA": "4741525e69841f2e22f9992af25df0c1112b07501f61f741c12c6389fcb119f3",
     "URL": "https://dl.google.com/go/go1.23.7.linux-amd64.tar.gz"
   },
+  "go1.23.8.linux-amd64.tar.gz": {
+    "SHA": "45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f",
+    "URL": "https://dl.google.com/go/go1.23.8.linux-amd64.tar.gz"
+  },
   "go1.24.0.linux-amd64.tar.gz": {
     "SHA": "dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858",
     "URL": "https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz"
@@ -958,6 +962,10 @@
   "go1.24.1.linux-amd64.tar.gz": {
     "SHA": "cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073",
     "URL": "https://dl.google.com/go/go1.24.1.linux-amd64.tar.gz"
+  },
+  "go1.24.2.linux-amd64.tar.gz": {
+    "SHA": "68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad",
+    "URL": "https://dl.google.com/go/go1.24.2.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",


### PR DESCRIPTION
This adds go1.24.2 and go1.23.8 and makes them the default for their respective lines.