### PR TITLE
Add go1.24.3, go1.23.9; make them the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## v207 - 2025-05-14
+
+* Add go1.24.3
+* Add go1.23.9
+* go1.24 defaults to 1.24.3
+* go1.23 defaults to 1.23.9
+
 ## [v206] - 2025-04-02
 
 * Add go1.24.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## v207 - 2025-05-14
+## [v207] - 2025-05-14
 
 * Add go1.24.3
 * Add go1.23.9
@@ -1077,7 +1077,8 @@
 
 * [GOPATH naming changed & update godep](https://github.com/heroku/heroku-buildpack-go/pull/82)
 
-[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v206...main
+[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v207...main
+[v207]: https://github.com/heroku/heroku-buildpack-go/compare/v206...v207
 [v206]: https://github.com/heroku/heroku-buildpack-go/compare/v205...v206
 [v205]: https://github.com/heroku/heroku-buildpack-go/compare/v204...v205
 [v204]: https://github.com/heroku/heroku-buildpack-go/compare/v203...v204

--- a/data.json
+++ b/data.json
@@ -1,154 +1,154 @@
 {
-    "Go": {
-        "DefaultVersion": "go1.20.14",
-        "VersionExpansion": {
-            "go1.24": "go1.24.3",
-            "go1.23": "go1.23.9",
-            "go1.22": "go1.22.12",
-            "go1.21": "go1.21.13",
-            "go1.20.0": "go1.20",
-            "go1.20": "go1.20.14",
-            "go1.19.0": "go1.19",
-            "go1.19": "go1.19.13",
-            "go1.18.0": "go1.18",
-            "go1.18": "go1.18.10",
-            "go1.17.0": "go1.17",
-            "go1.17": "go1.17.13",
-            "go1.16.0": "go1.16",
-            "go1.16": "go1.16.15",
-            "go1.15.0": "go1.15",
-            "go1.15": "go1.15.15",
-            "go1.14.0": "go1.14",
-            "go1.14": "go1.14.15",
-            "go1.13.0": "go1.13",
-            "go1.13": "go1.13.15",
-            "go1.12.0": "go1.12",
-            "go1.12": "go1.12.17",
-            "go1.11.0": "go1.11",
-            "go1.11": "go1.11.13",
-            "go1.10.0": "go1.10",
-            "go1.10": "go1.10.8",
-            "go1.9.0": "go1.9",
-            "go1.9": "go1.9.7",
-            "go1.8.0": "go1.8",
-            "go1.8": "go1.8.7",
-            "go1.7.0": "go1.7",
-            "go1.7": "go1.7.6",
-            "go1.6.0": "go1.6",
-            "go1.6": "go1.6.4",
-            "go1.5.0": "go1.5",
-            "go1.5": "go1.5.4",
-            "go1.4.0": "go1.4",
-            "go1.4": "go1.4.3",
-            "go1.3.0": "go1.3",
-            "go1.3": "go1.3.3",
-            "go1.2.0": "go1.2",
-            "go1.2": "go1.2.2",
-            "go1.1.0": "go1.1",
-            "go1.1": "go1.1.2",
-            "go1.0": "go1",
-            "go1": "go1.0.3"
-        },
-        "NeedsConcurrency": [
-            "go1",
-            "go1.0.1",
-            "go1.0.2",
-            "go1.0.3",
-            "go1.1",
-            "go1.1.1",
-            "go1.1.2",
-            "go1.2",
-            "go1.2.1",
-            "go1.2.2",
-            "go1.3",
-            "go1.3.1",
-            "go1.3.2",
-            "go1.3.3",
-            "go1.4",
-            "go1.4.1",
-            "go1.4.2",
-            "go1.4.3",
-            "go1.5",
-            "go1.5.1",
-            "go1.5.2",
-            "go1.5.3",
-            "go1.5.4"
-        ],
-        "SupportsVendorExperiment": [
-            "go1.5",
-            "go1.5.1",
-            "go1.5.2",
-            "go1.5.3",
-            "go1.5.4",
-            "go1.6",
-            "go1.6.1",
-            "go1.6.2",
-            "go1.6.3",
-            "go1.6.4"
-        ]
+  "Go": {
+    "DefaultVersion": "go1.20.14",
+    "VersionExpansion": {
+      "go1.24": "go1.24.3",
+      "go1.23": "go1.23.9",
+      "go1.22": "go1.22.12",
+      "go1.21": "go1.21.13",
+      "go1.20.0": "go1.20",
+      "go1.20": "go1.20.14",
+      "go1.19.0": "go1.19",
+      "go1.19": "go1.19.13",
+      "go1.18.0": "go1.18",
+      "go1.18": "go1.18.10",
+      "go1.17.0": "go1.17",
+      "go1.17": "go1.17.13",
+      "go1.16.0": "go1.16",
+      "go1.16": "go1.16.15",
+      "go1.15.0": "go1.15",
+      "go1.15": "go1.15.15",
+      "go1.14.0": "go1.14",
+      "go1.14": "go1.14.15",
+      "go1.13.0": "go1.13",
+      "go1.13": "go1.13.15",
+      "go1.12.0": "go1.12",
+      "go1.12": "go1.12.17",
+      "go1.11.0": "go1.11",
+      "go1.11": "go1.11.13",
+      "go1.10.0": "go1.10",
+      "go1.10": "go1.10.8",
+      "go1.9.0": "go1.9",
+      "go1.9": "go1.9.7",
+      "go1.8.0": "go1.8",
+      "go1.8": "go1.8.7",
+      "go1.7.0": "go1.7",
+      "go1.7": "go1.7.6",
+      "go1.6.0": "go1.6",
+      "go1.6": "go1.6.4",
+      "go1.5.0": "go1.5",
+      "go1.5": "go1.5.4",
+      "go1.4.0": "go1.4",
+      "go1.4": "go1.4.3",
+      "go1.3.0": "go1.3",
+      "go1.3": "go1.3.3",
+      "go1.2.0": "go1.2",
+      "go1.2": "go1.2.2",
+      "go1.1.0": "go1.1",
+      "go1.1": "go1.1.2",
+      "go1.0": "go1",
+      "go1": "go1.0.3"
     },
-    "Dep": {
-        "DefaultVersion": "v0.5.2"
-    },
-    "Glide": {
-        "DefaultVersion": "v0.13.3"
-    },
-    "Govendor": {
-        "DefaultVersion": "1.0.8"
-    },
-    "GB": {
-        "DefaultVersion": "0.4.4"
-    },
-    "PkgErrors": {
-        "DefaultVersion": "0.8.0"
-    },
-    "HG": {
-        "DefaultVersion": "3.9"
-    },
-    "MattesMigrate": {
-        "DefaultVersion": "v3.0.0"
-    },
-    "GolangMigrate": {
-        "DefaultVersion": "v3.4.0"
-    },
-    "tq": {
-        "DefaultVersion": "v0.5"
-    },
-    "test": {
-        "assets": [
-            "dep-v0.5.2-linux-amd64",
-            "errors-0.8.0.tar.gz",
-            "gb-0.4.4.tar.gz",
-            "glide-v0.13.3-linux-amd64.tar.gz",
-            "go1.10.8.linux-amd64.tar.gz",
-            "go1.11.13.linux-amd64.tar.gz",
-            "go1.12.17.linux-amd64.tar.gz",
-            "go1.13.15.linux-amd64.tar.gz",
-            "go1.14.2.linux-amd64.tar.gz",
-            "go1.15.15.linux-amd64.tar.gz",
-            "go1.16rc1.linux-amd64.tar.gz",
-            "go1.16.15.linux-amd64.tar.gz",
-            "go1.17.13.linux-amd64.tar.gz",
-            "go1.18.10.linux-amd64.tar.gz",
-            "go1.19.13.linux-amd64.tar.gz",
-            "go1.20.14.linux-amd64.tar.gz",
-            "go1.21.13.linux-amd64.tar.gz",
-            "go1.22.12.linux-amd64.tar.gz",
-            "go1.23.9.linux-amd64.tar.gz",
-            "go1.24.3.linux-amd64.tar.gz",
-            "go1.4.3.linux-amd64.tar.gz",
-            "go1.6.4.linux-amd64.tar.gz",
-            "go1.7.6.linux-amd64.tar.gz",
-            "go1.8.3.linux-amd64.tar.gz",
-            "godep_linux_amd64",
-            "golangci-lint-1.20.0-linux-amd64.tar.gz",
-            "govendor_linux_amd64",
-            "jq-linux64",
-            "mercurial-3.9.tar.gz",
-            "migrate-v3.0.0-linux-amd64.tar.gz",
-            "migrate-v3.4.0-linux-amd64.tar.gz",
-            "stdlib.sh.v8",
-            "tq-v0.5-linux-amd64"
-        ]
-    }
+    "NeedsConcurrency": [
+      "go1",
+      "go1.0.1",
+      "go1.0.2",
+      "go1.0.3",
+      "go1.1",
+      "go1.1.1",
+      "go1.1.2",
+      "go1.2",
+      "go1.2.1",
+      "go1.2.2",
+      "go1.3",
+      "go1.3.1",
+      "go1.3.2",
+      "go1.3.3",
+      "go1.4",
+      "go1.4.1",
+      "go1.4.2",
+      "go1.4.3",
+      "go1.5",
+      "go1.5.1",
+      "go1.5.2",
+      "go1.5.3",
+      "go1.5.4"
+    ],
+    "SupportsVendorExperiment": [
+      "go1.5",
+      "go1.5.1",
+      "go1.5.2",
+      "go1.5.3",
+      "go1.5.4",
+      "go1.6",
+      "go1.6.1",
+      "go1.6.2",
+      "go1.6.3",
+      "go1.6.4"
+    ]
+  },
+  "Dep": {
+    "DefaultVersion": "v0.5.2"
+  },
+  "Glide": {
+    "DefaultVersion": "v0.13.3"
+  },
+  "Govendor": {
+    "DefaultVersion": "1.0.8"
+  },
+  "GB": {
+    "DefaultVersion": "0.4.4"
+  },
+  "PkgErrors": {
+    "DefaultVersion": "0.8.0"
+  },
+  "HG": {
+    "DefaultVersion": "3.9"
+  },
+  "MattesMigrate": {
+    "DefaultVersion": "v3.0.0"
+  },
+  "GolangMigrate": {
+    "DefaultVersion": "v3.4.0"
+  },
+  "tq": {
+    "DefaultVersion": "v0.5"
+  },
+  "test": {
+    "assets": [
+      "dep-v0.5.2-linux-amd64",
+      "errors-0.8.0.tar.gz",
+      "gb-0.4.4.tar.gz",
+      "glide-v0.13.3-linux-amd64.tar.gz",
+      "go1.10.8.linux-amd64.tar.gz",
+      "go1.11.13.linux-amd64.tar.gz",
+      "go1.12.17.linux-amd64.tar.gz",
+      "go1.13.15.linux-amd64.tar.gz",
+      "go1.14.2.linux-amd64.tar.gz",
+      "go1.15.15.linux-amd64.tar.gz",
+      "go1.16rc1.linux-amd64.tar.gz",
+      "go1.16.15.linux-amd64.tar.gz",
+      "go1.17.13.linux-amd64.tar.gz",
+      "go1.18.10.linux-amd64.tar.gz",
+      "go1.19.13.linux-amd64.tar.gz",
+      "go1.20.14.linux-amd64.tar.gz",
+      "go1.21.13.linux-amd64.tar.gz",
+      "go1.22.12.linux-amd64.tar.gz",
+      "go1.23.9.linux-amd64.tar.gz",
+      "go1.24.3.linux-amd64.tar.gz",
+      "go1.4.3.linux-amd64.tar.gz",
+      "go1.6.4.linux-amd64.tar.gz",
+      "go1.7.6.linux-amd64.tar.gz",
+      "go1.8.3.linux-amd64.tar.gz",
+      "godep_linux_amd64",
+      "golangci-lint-1.20.0-linux-amd64.tar.gz",
+      "govendor_linux_amd64",
+      "jq-linux64",
+      "mercurial-3.9.tar.gz",
+      "migrate-v3.0.0-linux-amd64.tar.gz",
+      "migrate-v3.4.0-linux-amd64.tar.gz",
+      "stdlib.sh.v8",
+      "tq-v0.5-linux-amd64"
+    ]
+  }
 }

--- a/data.json
+++ b/data.json
@@ -1,154 +1,154 @@
 {
-  "Go": {
-    "DefaultVersion": "go1.20.14",
-    "VersionExpansion": {
-      "go1.24": "go1.24.2",
-      "go1.23": "go1.23.8",
-      "go1.22": "go1.22.12",
-      "go1.21": "go1.21.13",
-      "go1.20.0": "go1.20",
-      "go1.20": "go1.20.14",
-      "go1.19.0": "go1.19",
-      "go1.19": "go1.19.13",
-      "go1.18.0": "go1.18",
-      "go1.18": "go1.18.10",
-      "go1.17.0": "go1.17",
-      "go1.17": "go1.17.13",
-      "go1.16.0": "go1.16",
-      "go1.16": "go1.16.15",
-      "go1.15.0": "go1.15",
-      "go1.15": "go1.15.15",
-      "go1.14.0": "go1.14",
-      "go1.14": "go1.14.15",
-      "go1.13.0": "go1.13",
-      "go1.13": "go1.13.15",
-      "go1.12.0": "go1.12",
-      "go1.12": "go1.12.17",
-      "go1.11.0": "go1.11",
-      "go1.11": "go1.11.13",
-      "go1.10.0": "go1.10",
-      "go1.10": "go1.10.8",
-      "go1.9.0": "go1.9",
-      "go1.9": "go1.9.7",
-      "go1.8.0": "go1.8",
-      "go1.8": "go1.8.7",
-      "go1.7.0": "go1.7",
-      "go1.7": "go1.7.6",
-      "go1.6.0": "go1.6",
-      "go1.6": "go1.6.4",
-      "go1.5.0": "go1.5",
-      "go1.5": "go1.5.4",
-      "go1.4.0": "go1.4",
-      "go1.4": "go1.4.3",
-      "go1.3.0": "go1.3",
-      "go1.3": "go1.3.3",
-      "go1.2.0": "go1.2",
-      "go1.2": "go1.2.2",
-      "go1.1.0": "go1.1",
-      "go1.1": "go1.1.2",
-      "go1.0": "go1",
-      "go1": "go1.0.3"
+    "Go": {
+        "DefaultVersion": "go1.20.14",
+        "VersionExpansion": {
+            "go1.24": "go1.24.3",
+            "go1.23": "go1.23.9",
+            "go1.22": "go1.22.12",
+            "go1.21": "go1.21.13",
+            "go1.20.0": "go1.20",
+            "go1.20": "go1.20.14",
+            "go1.19.0": "go1.19",
+            "go1.19": "go1.19.13",
+            "go1.18.0": "go1.18",
+            "go1.18": "go1.18.10",
+            "go1.17.0": "go1.17",
+            "go1.17": "go1.17.13",
+            "go1.16.0": "go1.16",
+            "go1.16": "go1.16.15",
+            "go1.15.0": "go1.15",
+            "go1.15": "go1.15.15",
+            "go1.14.0": "go1.14",
+            "go1.14": "go1.14.15",
+            "go1.13.0": "go1.13",
+            "go1.13": "go1.13.15",
+            "go1.12.0": "go1.12",
+            "go1.12": "go1.12.17",
+            "go1.11.0": "go1.11",
+            "go1.11": "go1.11.13",
+            "go1.10.0": "go1.10",
+            "go1.10": "go1.10.8",
+            "go1.9.0": "go1.9",
+            "go1.9": "go1.9.7",
+            "go1.8.0": "go1.8",
+            "go1.8": "go1.8.7",
+            "go1.7.0": "go1.7",
+            "go1.7": "go1.7.6",
+            "go1.6.0": "go1.6",
+            "go1.6": "go1.6.4",
+            "go1.5.0": "go1.5",
+            "go1.5": "go1.5.4",
+            "go1.4.0": "go1.4",
+            "go1.4": "go1.4.3",
+            "go1.3.0": "go1.3",
+            "go1.3": "go1.3.3",
+            "go1.2.0": "go1.2",
+            "go1.2": "go1.2.2",
+            "go1.1.0": "go1.1",
+            "go1.1": "go1.1.2",
+            "go1.0": "go1",
+            "go1": "go1.0.3"
+        },
+        "NeedsConcurrency": [
+            "go1",
+            "go1.0.1",
+            "go1.0.2",
+            "go1.0.3",
+            "go1.1",
+            "go1.1.1",
+            "go1.1.2",
+            "go1.2",
+            "go1.2.1",
+            "go1.2.2",
+            "go1.3",
+            "go1.3.1",
+            "go1.3.2",
+            "go1.3.3",
+            "go1.4",
+            "go1.4.1",
+            "go1.4.2",
+            "go1.4.3",
+            "go1.5",
+            "go1.5.1",
+            "go1.5.2",
+            "go1.5.3",
+            "go1.5.4"
+        ],
+        "SupportsVendorExperiment": [
+            "go1.5",
+            "go1.5.1",
+            "go1.5.2",
+            "go1.5.3",
+            "go1.5.4",
+            "go1.6",
+            "go1.6.1",
+            "go1.6.2",
+            "go1.6.3",
+            "go1.6.4"
+        ]
     },
-    "NeedsConcurrency": [
-      "go1",
-      "go1.0.1",
-      "go1.0.2",
-      "go1.0.3",
-      "go1.1",
-      "go1.1.1",
-      "go1.1.2",
-      "go1.2",
-      "go1.2.1",
-      "go1.2.2",
-      "go1.3",
-      "go1.3.1",
-      "go1.3.2",
-      "go1.3.3",
-      "go1.4",
-      "go1.4.1",
-      "go1.4.2",
-      "go1.4.3",
-      "go1.5",
-      "go1.5.1",
-      "go1.5.2",
-      "go1.5.3",
-      "go1.5.4"
-    ],
-    "SupportsVendorExperiment": [
-      "go1.5",
-      "go1.5.1",
-      "go1.5.2",
-      "go1.5.3",
-      "go1.5.4",
-      "go1.6",
-      "go1.6.1",
-      "go1.6.2",
-      "go1.6.3",
-      "go1.6.4"
-    ]
-  },
-  "Dep": {
-    "DefaultVersion": "v0.5.2"
-  },
-  "Glide": {
-    "DefaultVersion": "v0.13.3"
-  },
-  "Govendor": {
-    "DefaultVersion": "1.0.8"
-  },
-  "GB": {
-    "DefaultVersion": "0.4.4"
-  },
-  "PkgErrors": {
-    "DefaultVersion": "0.8.0"
-  },
-  "HG": {
-    "DefaultVersion": "3.9"
-  },
-  "MattesMigrate": {
-    "DefaultVersion": "v3.0.0"
-  },
-  "GolangMigrate": {
-    "DefaultVersion": "v3.4.0"
-  },
-  "tq": {
-    "DefaultVersion": "v0.5"
-  },
-  "test": {
-    "assets": [
-      "dep-v0.5.2-linux-amd64",
-      "errors-0.8.0.tar.gz",
-      "gb-0.4.4.tar.gz",
-      "glide-v0.13.3-linux-amd64.tar.gz",
-      "go1.10.8.linux-amd64.tar.gz",
-      "go1.11.13.linux-amd64.tar.gz",
-      "go1.12.17.linux-amd64.tar.gz",
-      "go1.13.15.linux-amd64.tar.gz",
-      "go1.14.2.linux-amd64.tar.gz",
-      "go1.15.15.linux-amd64.tar.gz",
-      "go1.16rc1.linux-amd64.tar.gz",
-      "go1.16.15.linux-amd64.tar.gz",
-      "go1.17.13.linux-amd64.tar.gz",
-      "go1.18.10.linux-amd64.tar.gz",
-      "go1.19.13.linux-amd64.tar.gz",
-      "go1.20.14.linux-amd64.tar.gz",
-      "go1.21.13.linux-amd64.tar.gz",
-      "go1.22.12.linux-amd64.tar.gz",
-      "go1.23.8.linux-amd64.tar.gz",
-      "go1.24.2.linux-amd64.tar.gz",
-      "go1.4.3.linux-amd64.tar.gz",
-      "go1.6.4.linux-amd64.tar.gz",
-      "go1.7.6.linux-amd64.tar.gz",
-      "go1.8.3.linux-amd64.tar.gz",
-      "godep_linux_amd64",
-      "golangci-lint-1.20.0-linux-amd64.tar.gz",
-      "govendor_linux_amd64",
-      "jq-linux64",
-      "mercurial-3.9.tar.gz",
-      "migrate-v3.0.0-linux-amd64.tar.gz",
-      "migrate-v3.4.0-linux-amd64.tar.gz",
-      "stdlib.sh.v8",
-      "tq-v0.5-linux-amd64"
-    ]
-  }
+    "Dep": {
+        "DefaultVersion": "v0.5.2"
+    },
+    "Glide": {
+        "DefaultVersion": "v0.13.3"
+    },
+    "Govendor": {
+        "DefaultVersion": "1.0.8"
+    },
+    "GB": {
+        "DefaultVersion": "0.4.4"
+    },
+    "PkgErrors": {
+        "DefaultVersion": "0.8.0"
+    },
+    "HG": {
+        "DefaultVersion": "3.9"
+    },
+    "MattesMigrate": {
+        "DefaultVersion": "v3.0.0"
+    },
+    "GolangMigrate": {
+        "DefaultVersion": "v3.4.0"
+    },
+    "tq": {
+        "DefaultVersion": "v0.5"
+    },
+    "test": {
+        "assets": [
+            "dep-v0.5.2-linux-amd64",
+            "errors-0.8.0.tar.gz",
+            "gb-0.4.4.tar.gz",
+            "glide-v0.13.3-linux-amd64.tar.gz",
+            "go1.10.8.linux-amd64.tar.gz",
+            "go1.11.13.linux-amd64.tar.gz",
+            "go1.12.17.linux-amd64.tar.gz",
+            "go1.13.15.linux-amd64.tar.gz",
+            "go1.14.2.linux-amd64.tar.gz",
+            "go1.15.15.linux-amd64.tar.gz",
+            "go1.16rc1.linux-amd64.tar.gz",
+            "go1.16.15.linux-amd64.tar.gz",
+            "go1.17.13.linux-amd64.tar.gz",
+            "go1.18.10.linux-amd64.tar.gz",
+            "go1.19.13.linux-amd64.tar.gz",
+            "go1.20.14.linux-amd64.tar.gz",
+            "go1.21.13.linux-amd64.tar.gz",
+            "go1.22.12.linux-amd64.tar.gz",
+            "go1.23.9.linux-amd64.tar.gz",
+            "go1.24.3.linux-amd64.tar.gz",
+            "go1.4.3.linux-amd64.tar.gz",
+            "go1.6.4.linux-amd64.tar.gz",
+            "go1.7.6.linux-amd64.tar.gz",
+            "go1.8.3.linux-amd64.tar.gz",
+            "godep_linux_amd64",
+            "golangci-lint-1.20.0-linux-amd64.tar.gz",
+            "govendor_linux_amd64",
+            "jq-linux64",
+            "mercurial-3.9.tar.gz",
+            "migrate-v3.0.0-linux-amd64.tar.gz",
+            "migrate-v3.4.0-linux-amd64.tar.gz",
+            "stdlib.sh.v8",
+            "tq-v0.5-linux-amd64"
+        ]
+    }
 }

--- a/files.json
+++ b/files.json
@@ -955,6 +955,10 @@
     "SHA": "45b87381172a58d62c977f27c4683c8681ef36580abecd14fd124d24ca306d3f",
     "URL": "https://dl.google.com/go/go1.23.8.linux-amd64.tar.gz"
   },
+  "go1.23.9.linux-amd64.tar.gz": {
+    "SHA": "de03e45d7a076c06baaa9618d42b3b6a0561125b87f6041c6397680a71e5bb26",
+    "URL": "https://dl.google.com/go/go1.23.9.linux-amd64.tar.gz"
+  },
   "go1.24.0.linux-amd64.tar.gz": {
     "SHA": "dea9ca38a0b852a74e81c26134671af7c0fbe65d81b0dc1c5bfe22cf7d4c8858",
     "URL": "https://dl.google.com/go/go1.24.0.linux-amd64.tar.gz"
@@ -966,6 +970,10 @@
   "go1.24.2.linux-amd64.tar.gz": {
     "SHA": "68097bd680839cbc9d464a0edce4f7c333975e27a90246890e9f1078c7e702ad",
     "URL": "https://dl.google.com/go/go1.24.2.linux-amd64.tar.gz"
+  },
+  "go1.24.3.linux-amd64.tar.gz": {
+    "SHA": "3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8",
+    "URL": "https://dl.google.com/go/go1.24.3.linux-amd64.tar.gz"
   },
   "go1.3.1.linux-amd64.tar.gz": {
     "SHA": "3af011cc19b21c7180f2604fd85fbc4ddde97143",


### PR DESCRIPTION
This adds go1.24.3 and go1.23.9 and makes them the default for their respective lines.

This also bumps the version and marks the release for today (which I'll do after merge).