### PR TITLE
Fix changelog contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1101,7 +1101,8 @@
 
 * [GOPATH naming changed & update godep](https://github.com/heroku/heroku-buildpack-go/pull/82)
 
-[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v209...main
+[unreleased]: https://github.com/heroku/heroku-buildpack-go/compare/v210...main
+[v210]: https://github.com/heroku/heroku-buildpack-go/compare/v209...v210
 [v209]: https://github.com/heroku/heroku-buildpack-go/compare/v208...v209
 [v208]: https://github.com/heroku/heroku-buildpack-go/compare/v207...v208
 [v207]: https://github.com/heroku/heroku-buildpack-go/compare/v206...v207

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,22 @@
 
 ## [Unreleased]
 
-## [v209] - 2025-07-08
+## [v210] - 2025-08-08
 
-* Add go1.24.5
-* Add go1.23.11
-* go1.24 defaults to 1.24.5
-* go1.23 defaults to 1.23.11
-* Stop testing against the Heroku-20 stack.
 * Add go1.25rc3
 * Add go1.24.6
 * Add go1.23.12
 * go1.25 defaults to 1.25rc3
 * go1.24 defaults to 1.24.6
 * go1.23 defaults to 1.23.12
+
+## [v209] - 2025-07-09
+
+* Add go1.24.5
+* Add go1.23.11
+* go1.24 defaults to 1.24.5
+* go1.23 defaults to 1.23.11
+* Stop testing against the Heroku-20 stack.
 
 ## [v208] - 2025-06-17
 


### PR DESCRIPTION
- v209 was released on July the 9th https://github.com/heroku/heroku-buildpack-go/releases/tag/v209
- v210 is the latest release and contains the contents of https://github.com/heroku/heroku-buildpack-go/pull/598#discussion_r2268814411 which was put in the wrong section. It was tagged on August the 8th https://github.com/heroku/heroku-buildpack-go/releases/tag/v210