### PR TITLE
Add detection failure error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add detection failure error output
 
 ## [v212] - 2025-09-08
 

--- a/bin/detect
+++ b/bin/detect
@@ -3,6 +3,9 @@
 set -e
 
 build=$(cd "$1/" && pwd)
+buildpack=$(cd "$(dirname $0)/.." && pwd)
+
+source "${buildpack}/lib/common.sh"
 
 if test -f "${build}/go.mod" || #go modules
    test -f "${build}/Gopkg.lock" || #dep
@@ -13,5 +16,34 @@ if test -f "${build}/go.mod" || #go modules
 then
   echo Go
 else
+  {
+    cat <<EOF
+Error: Your app is configured to use the Go buildpack,
+but we couldn't find a go.mod file.
+
+A Go app on Heroku must have a 'go.mod' file in the root
+directory of its source code.
+
+Currently the root directory of your app contains:
+
+$(ls -1A --indicator-style=slash "${build}" || true)
+
+If your app already has a go.mod file, check that it:
+
+1. Is in the top level directory (not a subdirectory).
+2. Has the correct spelling (the filenames are case-sensitive).
+3. Isn't listed in '.gitignore' or '.slugignore'.
+4. Has been added to Git using 'git add --all' and committed.
+
+To create a go.mod file, run 'go mod init <module-name>' in your
+project directory.
+
+For help with using Go on Heroku, see:
+https://devcenter.heroku.com/articles/getting-started-with-go
+https://devcenter.heroku.com/articles/go-support
+EOF
+  } | while IFS= read -r line; do
+    err "${line}"
+  done
   exit 1
 fi


### PR DESCRIPTION
## Summary

Improves the `bin/detect` script to provide helpful error messages when Go projects are missing required dependency management files, following the pattern established by the Python buildpack.

## Changes

- **Enhanced error messaging**: When detection fails, shows a clear explanation of what's required
- **Directory listing**: Displays actual project contents to help users debug issues
- **Actionable guidance**: Provides specific steps to fix common problems
- **Go modules focus**: Recommends `go.mod` as the modern standard while maintaining backward compatibility

## Before/After

### Before
```
(silent failure - exits with code 1, no helpful output)
```

### After
```
Error: Your app is configured to use the Go buildpack,
but we couldn't find a go.mod file.

A Go app on Heroku must have a 'go.mod' file in the root
directory of its source code.

Currently the root directory of your app contains:

README.md
docs/
main.go
package.json
src/

If your app already has a go.mod file, check that it:

1. Is in the top level directory (not a subdirectory).
2. Has the correct spelling (the filenames are case-sensitive).
3. Isn't listed in '.gitignore' or '.slugignore'.
4. Has been added to Git using 'git add --all' and committed.

To create a go.mod file, run 'go mod init <module-name>' in your
project directory.

For help with using Go on Heroku, see:
https://devcenter.heroku.com/articles/getting-started-with-go
https://devcenter.heroku.com/articles/go-support
```

## Implementation Details

- Uses existing `err` function from `lib/common.sh` for consistent formatting
- Leverages heredoc (EOF) pattern for clean, maintainable error messages
- Shows directories with `/` suffix for better visual distinction
- Maintains all existing detection logic - no breaking changes
- Only adds error output, doesn't change detection behavior

GUS-W-19615938