### PR TITLE
Move build cache to dedicated `.heroku/go` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix bug where Go version changes deleted the shared buildpack build cache
 
 ## [v220] - 2026-02-10
 

--- a/bin/compile
+++ b/bin/compile
@@ -19,6 +19,28 @@ source_stdlib
 
 snapshotBinBefore
 
+# Clean up old cache files if migrating from old cache structure.
+# We detect this legacy structure by looking for 'go-path' in the root.
+# TODO: Remove following migration/after a few months
+if [ -d "${cache_root}/go-path" ] && [ ! -d "${cache}/go-path" ]; then
+    step "Clearing old build cache artifacts"
+
+    # Remove artifacts that were previously stored in the cache root
+    rm -rf "${cache_root}"/go[0-9]* \
+           "${cache_root}"/devel-* \
+           "${cache_root}/go-path" \
+           "${cache_root}/go-build-cache" \
+           "${cache_root}/glide" \
+           "${cache_root}/gb" \
+           "${cache_root}/dep" \
+           "${cache_root}/godep" \
+           "${cache_root}/govendor" \
+           "${cache_root}/.tq" \
+           "${cache_root}/.jq" \
+           "${cache_root}/github.com/golang-migrate" \
+           "${cache_root}/github.com/mattes" 2>/dev/null || true
+fi
+
 DefaultGoVersion="$(<${DataJSON} jq -r '.Go.DefaultVersion')"
 DepVersion="$(<${DataJSON} jq -r '.Dep.DefaultVersion')"
 GlideVersion="$(<${DataJSON} jq -r '.Glide.DefaultVersion')"

--- a/bin/compile
+++ b/bin/compile
@@ -7,7 +7,9 @@ set -eo pipefail
 
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
-cache=$(cd "$2/" && pwd)
+cache_root=$(cd "$2/" && pwd)
+cache="${cache_root}/.heroku/go"
+mkdir -p "${cache}"
 env_dir="${3}"
 buildpack=$(cd "$(dirname $0)/.." && pwd)
 
@@ -257,7 +259,7 @@ ensureGo() {
     if [ -d "${goPath}" ]; then
         step "Using ${goVersion}"
     else
-        #For a go version change, we delete everything
+        #For a go version change, we delete everything in our namespace
         step "New Go Version, clearing old cache"
         if [ -d "${cache}/go-path" ]; then
             find "${cache}/go-path" ! -perm -u=w -print0 | xargs -r -0 chmod u+w 2>&1

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,6 @@ snapshotBinBefore
 
 # Clean up old cache files if migrating from old cache structure.
 # We detect this legacy structure by looking for 'go-path' in the root.
-# TODO: Remove following migration/after a few months
 if [ -d "${cache_root}/go-path" ] && [ ! -d "${cache}/go-path" ]; then
     step "Clearing old build cache artifacts"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -1554,7 +1554,7 @@ testGodepPackageSpec() {
 }
 
 testGoCacheGoVersionGreaterThanOrEqualTo110() {
-  local cache_dir="${CACHE_DIR}/go-build-cache"
+  local cache_dir="${CACHE_DIR}/.heroku/go/go-build-cache"
 
   fixture "dep-go-1-10"
 
@@ -1574,7 +1574,7 @@ testGoCacheGoVersionGreaterThanOrEqualTo110() {
 }
 
 testGoCacheGoVersionLessThan110() {
-  local cache_dir="${CACHE_DIR}/go-build-cache"
+  local cache_dir="${CACHE_DIR}/.heroku/go/go-build-cache"
 
   fixture "dep-go-version"
 


### PR DESCRIPTION
The Go buildpack currently deletes the **shared build cache directory** (including other buildpacks' build caches) whenever the Go version changes.

This is triggered in [the `ensureGo()` function](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L265), when the Go version changes, on the first build of a project, etc., and can cause a number of issues including:

- **Performance degradation**: Invalidates caches for other buildpacks, forcing unnecessary downloads, compilation etc across the entire build
- **Metadata loss**: May break features like sticky-versioning and persistent secrets in other buildpacks

GUS-W-20882902

## Changes

This PR addresses the issue by moving all Go buildpack cache operations into a dedicated/isolated namespace: `${CACHE_DIR}/.heroku/go`:

- **bin/compile**
  - Namespace build cache under `.heroku/go`
  - Initialize `cache_root` (ie `CACHE_DIR`) and `cache="${cache_root}/.heroku/go"`
  - Add cleanup logic to remove old cache artifacts
- **test/run.sh** - Update test assertions for new cache structure

**Before:**
```
${CACHE_DIR}/
├── go1.25/go/              # Mixed with other buildpacks
├── go-build-cache/
├── node-modules/           # Other buildpack (affected by rm -rf)
└── ruby-gems/              # Other buildpack (affected by rm -rf)
```

**After:**
```
${CACHE_DIR}/
├── .heroku/
│   └── go/                 # Isolated Go build cache
│       ├── go1.25/go/
│       ├── go-build-cache/
│       ├── go-path/
│       ├── glide/
│       └── ...
├── node-modules/           # Other buildpacks (preserved)
└── ruby-gems/              # Other buildpacks (preserved)
```

Now when `rm -rf ${cache}/*` is executed, it only deletes files within `${CACHE_DIR}/.heroku/go/*`.

## Current Cache Locations

Before this change, the Go buildpack created the following directories directly in the root (`CACHE_DIR`) of the shared buildpack cache directory:

### Go Compiler and Runtime
- **`${cache}/go<version>/go/`** - Go compiler installations (versioned)
  - Code: [bin/compile:254](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L254)
  - Example: `${cache}/go1.25.7/go/`

- **`${cache}/devel-<sha>/`** - Development Go builds
  - Code: [bin/compile:287-305](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L287-L305)
  - Example: `${cache}/devel-abc123/go/`

- **`${cache}/go-build-cache/`** - Go 1.10+ build cache (GOCACHE)
  - Code: [bin/compile:317](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L317)

- **`${cache}/go-path/`** - Module and dependency cache (GOPATH)
  - Code: [bin/compile:262](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L262), [bin/compile:481](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L481)

### Dependency Management Tools

- **`${cache}/glide/${version}/bin/`** - Glide package manager binary
  - Code: [bin/compile:132](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L132)
  - Example: `${cache}/glide/v0.13.3/bin/glide`

- **`${cache}/gb/${version}/`** - GB tool and workspace (GOPATH-based build tool)
  - Code: [bin/compile:228](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L228)
  - Example: `${cache}/gb/0.4.4/`

- **`${cache}/dep/bin/`** - Dep tool binary (official dependency management)
  - Code: [bin/compile:559](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L559)

- **`${cache}/godep/bin/`** - Godep tool binary (legacy dependency management)
  - Code: [bin/compile:598](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L598)

- **`${cache}/govendor/bin/`** - Govendor tool binary (vendor management)
  - Code: [bin/compile:608](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L608)

### Utility Tools

- **`${cache}/.tq/bin/`** - TOML query utility (for parsing Gopkg.toml)
  - Code: [bin/compile:365](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L365)

- **`${cache}/.jq/bin/`** - JSON query utility (for parsing data.json/files.json)
  - Code: [lib/common_tools.sh:4](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/lib/common_tools.sh#L4)

### Migration Tools

- **`${cache}/github.com/golang-migrate/migrate/${version}/`** - golang-migrate migration tool
  - Code: [bin/compile:153](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L153)

- **`${cache}/github.com/mattes/migrate/${version}/`** - mattes/migrate migration tool (deprecated)
  - Code: [bin/compile:153](https://github.com/heroku/heroku-buildpack-go/blob/d1766c49d2bbf78ce2029fcb7a02e6bba9d1f510/bin/compile#L153)