### PR TITLE
Add initial `bin/report` implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      # Test both the local development `make run` workflow and that `bin/report` completes successfully
+      # for both passing and failing builds (since `bin/report` can't easily be tested via Hatchet tests).
       - name: Run buildpack using default app fixture
         run: make run
+      - name: Run buildpack using an app fixture that's expected to fail
+        run: make run FIXTURE=test/fixtures/godep-bin-file COMPILE_FAILURE_EXIT_CODE=0
       - name: Run buildpack testpack script using legacy fixture
         run: make run-ci FIXTURE=test/fixtures/govendor-basic

--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,14 @@ source "${buildpack}/lib/common.sh"
 source "${buildpack}/lib/common_tools.sh"
 source_stdlib
 
+# Set CACHE_DIR (used by build_data)
+CACHE_DIR="${cache_root}"
+source "${buildpack}/lib/build_data.sh"
+# Initialise the build data store used to track state across builds (for cache invalidation
+# and messaging when build configuration changes) and also so that `bin/report` can generate
+# a build report that will be consumed by the build system for observability.
+build_data::setup
+
 snapshotBinBefore
 
 # Clean up old cache files if migrating from old cache structure.

--- a/bin/compile
+++ b/bin/compile
@@ -428,6 +428,9 @@ FLAGS=(-tags heroku)
 
 determineTool
 
+# Track the package management tool detected
+build_data::set_string "go_tool" "${TOOL}"
+
 # Track the requested Go version before expansion
 requested_go_version="${ver}"
 build_data::set_string "go_version_requested" "${requested_go_version}"

--- a/bin/compile
+++ b/bin/compile
@@ -349,18 +349,6 @@ ensureGo() {
     fi
 }
 
-setGoVersionFromEnvironment() {
-    if [ -z "${GOVERSION}" ]; then
-        warn ""
-        warn "'GOVERSION' isn't set, defaulting to '${DefaultGoVersion}'"
-        warn ""
-        warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
-        warn "for future builds"
-        warn ""
-    fi
-    ver=${GOVERSION:-$DefaultGoVersion}
-}
-
 warnGoVersionOverride() {
     if [ ! -z "${GOVERSION}" ]; then
         warn "Using \$GOVERSION override."

--- a/bin/compile
+++ b/bin/compile
@@ -421,7 +421,7 @@ requested_go_version="${ver}"
 
 # Expand the version and track the resolved version
 ver=$(expandVer $ver)
-build_data::set_string "go_full_version" "${ver}"
+build_data::set_string "go_version" "${ver}"
 
 # Track whether the version was pinned (fully specified)
 if [ "${requested_go_version}" = "${ver}" ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -428,14 +428,10 @@ FLAGS=(-tags heroku)
 
 determineTool
 
-# Track the package management tool detected
-build_data::set_string "go_tool" "${TOOL}"
-
-# Track the requested Go version before expansion
+# Track the requested version before expansion (for pinned check)
 requested_go_version="${ver}"
-build_data::set_string "go_version_requested" "${requested_go_version}"
-build_data::set_string "go_version_origin" "${go_version_origin}"
 
+# Expand the version and track the resolved version
 ver=$(expandVer $ver)
 build_data::set_string "go_full_version" "${ver}"
 

--- a/bin/compile
+++ b/bin/compile
@@ -428,7 +428,20 @@ FLAGS=(-tags heroku)
 
 determineTool
 
+# Track the requested Go version before expansion
+requested_go_version="${ver}"
+build_data::set_string "go_version_requested" "${requested_go_version}"
+build_data::set_string "go_version_origin" "${go_version_origin}"
+
 ver=$(expandVer $ver)
+build_data::set_string "go_full_version" "${ver}"
+
+# Track whether the version was pinned (fully specified)
+if [ "${requested_go_version}" = "${ver}" ]; then
+    build_data::set_raw "go_version_pinned" "true"
+else
+    build_data::set_raw "go_version_pinned" "false"
+fi
 
 # If $GO_LINKER_SYMBOL and GO_LINKER_VALUE are set, tell the linker to DTRT
 if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]; then

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Usage: bin/report <build-dir> <cache-dir> <env-dir>
+
+# Produces a build report emitted to stdout, containing metadata about the build, that's
+# consumed by the build system. See the pip_spec.rb for an example build report payload.
+#
+# This script is run for both successful and failing builds, so it should not assume the
+# build ran to completion (e.g. Python or other tools may not even have been installed).
+#
+# Failures in this script don't cause the overall build to fail (and won't appear in user
+# facing build logs) to avoid breaking builds unnecessarily / causing confusion. To debug
+# issues check the internal build system logs for `buildpack.report.failed` events, or
+# when developing run `make run` in this repo locally, which runs `bin/report` too.
+#
+# Note: The build system doesn't source the `export` script before running this script,
+# so Python/the package manager won't be on PATH by default.
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+CACHE_DIR="${2}"
+
+# The absolute path to the root of the buildpack.
+BUILDPACK_DIR=$(cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")" && pwd)
+
+source "${BUILDPACK_DIR}/lib/build_data.sh"
+
+build_data::print_bin_report_json

--- a/lib/build_data.sh
+++ b/lib/build_data.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+
+# Note: -u is omitted for now so we don't break non-strict callers.
+set -eo pipefail
+
+BUILD_DATA_FILE="${CACHE_DIR:?}/build-data/go.json"
+PREVIOUS_BUILD_DATA_FILE="${CACHE_DIR:?}/build-data/go-prev.json"
+
+# Initializes the build data store, preserving the file from the previous build if it exists.
+# Call this at the start of `bin/compile` before using any other functions from this file.
+#
+# Usage:
+# ```
+# build_data::setup
+# ```
+function build_data::setup() {
+	if [[ -f "${BUILD_DATA_FILE}" ]]; then
+		# Rename the existing build data file rather than overwriting it, so we can lookup values
+		# from the previous build (such as when determining whether to invalidate the cache).
+		mv "${BUILD_DATA_FILE}" "${PREVIOUS_BUILD_DATA_FILE}"
+	else
+		mkdir -p "$(dirname "${BUILD_DATA_FILE}")"
+	fi
+
+	echo "{}" >"${BUILD_DATA_FILE}"
+}
+
+# Sets a string build data value. The value will be wrapped in double quotes and escaped for JSON.
+#
+# Usage:
+# ```
+# build_data::set_string "python_version" "1.2.3"
+# build_data::set_string "failure_reason" "install-dependencies::pip"
+# ```
+function build_data::set_string() {
+	local key="${1}"
+	local value="${2}"
+	build_data::_set "${key}" "${value}" "true"
+}
+
+# Sets a build data value for the elapsed time in seconds between the provided start time and the
+# current time, represented as a float with microseconds precision.
+#
+# Usage:
+# ```
+# local dependencies_install_start_time=$(build_data::current_unix_realtime)
+# # ... some operation ...
+# build_data::set_duration "dependencies_install_duration" "${dependencies_install_start_time}"
+# ```
+function build_data::set_duration() {
+	local key="${1}"
+	local start_time="${2}"
+	local end_time duration
+	end_time="$(build_data::current_unix_realtime)"
+	duration="$(awk -v start="${start_time}" -v end="${end_time}" 'BEGIN { printf "%f", (end - start) }')"
+	build_data::set_raw "${key}" "${duration}"
+}
+
+# Sets a build data value as raw JSON data. The value parameter must be valid JSON value, that's also
+# a supported Honeycomb data type (string, integer, float, or boolean only; no arrays or objects).
+# For strings, use `build_data::set_string` instead since it will handle the escaping/quoting for you.
+# And for durations, use `build_data::set_duration`.
+#
+# Usage:
+# ```
+# build_data::set_raw "python_version_outdated" "true"
+# build_data::set_raw "foo_size_mb" "42.5"
+# ```
+function build_data::set_raw() {
+	local key="${1}"
+	local value="${2}"
+	build_data::_set "${key}" "${value}" "false"
+}
+
+# Internal helper to write a key/value pair to the build data store. The buildpack shouldn't call this directly.
+# Takes a key, value, and a boolean flag indicating whether the value needs to be quoted.
+#
+# Usage:
+# ```
+# build_data::_set "foo_string" "quote me" "true"
+# build_data::_set "bar_number" "99" "false"
+# ```
+function build_data::_set() {
+	local key="${1}"
+	# Truncate the value to an arbitrary 200 characters since it will sometimes contain user-provided
+	# inputs which may be unbounded in size. Ideally individual call sites will perform more aggressive
+	# truncation themselves based on the expected value size, however this is here as a fallback.
+	# (Honeycomb supports string fields up to 64KB in size, however, it's not worth filling up the
+	# build data store or bloating the payload passed back to Vacuole/submitted to Honeycomb given the
+	# extra content in those cases is not normally useful.)
+	local value="${2:0:200}"
+	local needs_quoting="${3}"
+
+	if [[ "${needs_quoting}" == "true" ]]; then
+		# Values passed using `--arg` are treated as strings, and so have double quotes added and any JSON
+		# special characters (such as newlines, carriage returns, double quotes, backslashes) are escaped.
+		local jq_args=(--arg value "${value}")
+	else
+		# Values passed using `--argjson` are treated as raw JSON values, and so aren't escaped or quoted.
+		local jq_args=(--argjson value "${value}")
+	fi
+
+	if [[ -f "${BUILD_DATA_FILE}" ]]; then
+		local new_data_file_contents
+		new_data_file_contents="$(jq --exit-status --arg key "${key}" "${jq_args[@]}" '. + { ($key): ($value) }' "${BUILD_DATA_FILE}")"
+		echo "${new_data_file_contents}" >"${BUILD_DATA_FILE}"
+	else
+		err "Error: Can't find the buildpack's build data file."
+        err ""
+		err "The Go buildpack's internal build data file is missing:"
+        err "${BUILD_DATA_FILE}"
+        err ""
+		err "This file is required for the buildpack to work correctly,"
+		err "and so you must not delete it when removing files from the"
+		err "build cache or /tmp directories."
+		build_data::setup
+		build_data::set_string "failure_reason" "build-data::data-file-deleted"
+		exit 1
+	fi
+}
+
+# Check whether an entry exists in the build data store for the current build.
+# Returns zero if the key was found and non-zero otherwise.
+#
+# Usage:
+# ```
+# build_data::has "failure_reason"
+# ```
+function build_data::has() {
+	local key="${1}"
+
+	jq --exit-status "has(\"${key}\")" "${BUILD_DATA_FILE}" >/dev/null
+}
+
+# Retrieve the value of an entry in the build data store from the previous successful build.
+# Returns the empty string if the key wasn't found in the store.
+#
+# Usage:
+# ```
+# build_data::get_previous "python_version"
+# ```
+function build_data::get_previous() {
+	local key="${1}"
+
+	if [[ -f "${PREVIOUS_BUILD_DATA_FILE}" ]]; then
+		# The `// empty` ensures we return the empty string rather than `null` if the key doesn't exist.
+		# We don't use `--exit-status` since `false` is a valid value for us to retrieve.
+		jq --raw-output ".${key} // empty" "${PREVIOUS_BUILD_DATA_FILE}"
+	fi
+}
+
+# Returns the current time since the UNIX Epoch, as a float with microseconds precision.
+#
+# Usage:
+# ```
+# local dependencies_install_start_time=$(build_data::current_unix_realtime)
+# # ... some operation ...
+# build_data::set_duration "dependencies_install_duration" "${dependencies_install_start_time}"
+# ```
+function build_data::current_unix_realtime() {
+	# We use a subshell with `LC_ALL=C` to ensure the output format isn't affected by system locale.
+	(
+		LC_ALL=C
+		echo "${EPOCHREALTIME}"
+	)
+}
+
+# Prints the contents of the build data store in sorted JSON format.
+#
+# Usage:
+# ```
+# build_data::print_bin_report_json
+# ```
+function build_data::print_bin_report_json() {
+	jq --exit-status --sort-keys '.' "${BUILD_DATA_FILE}"
+}

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -317,6 +317,9 @@ setGoVersionFromEnvironment() {
         warn "Run 'heroku config:set GOVERSION=goX.Y' to set the Go version to use"
         warn "for future builds"
         warn ""
+        go_version_origin="default"
+    else
+        go_version_origin="GOVERSION"
     fi
     ver=${GOVERSION:-$DefaultGoVersion}
 }
@@ -328,19 +331,40 @@ supportsGoModules() {
 }
 
 determineTool() {
+    # Check GOVERSION first - it overrides all tool-specific configurations
+    if [ -n "${GOVERSION}" ]; then
+        ver="${GOVERSION}"
+        go_version_origin="GOVERSION"
+    fi
+
     if [ -f "${goMOD}" ]; then
         TOOL="gomodules"
         step ""
         info "Detected go modules via go.mod"
         step ""
-        ver=${GOVERSION:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})}
-        ver=${ver:-$(awk '{ if ($1 == "go" ) { print "go" $2; exit } }' ${goMOD})}
+
+        # Determine Go version from go.mod if not already set by GOVERSION
+        if [ -z "${ver}" ]; then
+            ver=$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "goVersion" ) { print $4; exit } }' ${goMOD})
+            if [ -n "${ver}" ]; then
+                go_version_origin="go.mod (heroku comment)"
+            else
+                ver=$(awk '{ if ($1 == "go" ) { print "go" $2; exit } }' ${goMOD})
+                if [ -n "${ver}" ]; then
+                    go_version_origin="go.mod"
+                else
+                    ver=${DefaultGoVersion}
+                    go_version_origin="default"
+                fi
+            fi
+        fi
+
         name=$(awk '{ if ($1 == "module" ) { gsub(/"/, "", $2); print $2; exit } }' < ${goMOD})
         info "Detected Module Name: ${name}"
         step ""
         warnGoVersionOverride
-        if [ -z "${ver}" ]; then
-            ver=${DefaultGoVersion}
+
+        if [ "${go_version_origin}" = "default" ]; then
             warn "The go.mod file for this project does not specify a Go version"
             warn ""
             warn "Defaulting to ${ver}"
@@ -371,10 +395,21 @@ determineTool() {
             err "For more details see: https://devcenter.heroku.com/articles/go-apps-with-dep#build-configuration"
             exit 1
         fi
-        ver=${GOVERSION:-$(<${depTOML} tq '$.metadata.heroku["go-version"]')}
-        warnGoVersionOverride
+
+        # Determine Go version from Gopkg.toml if not already set by GOVERSION
         if [ -z "${ver}" ]; then
-            ver=${DefaultGoVersion}
+            ver=$(<${depTOML} tq '$.metadata.heroku["go-version"]')
+            if [ -n "${ver}" ]; then
+                go_version_origin="Gopkg.toml"
+            else
+                ver=${DefaultGoVersion}
+                go_version_origin="default"
+            fi
+        fi
+
+        warnGoVersionOverride
+
+        if [ "${go_version_origin}" = "default" ]; then
             warn "The 'metadata.heroku[\"go-version\"]' field is not specified in 'Gopkg.toml'."
             warn ""
             warn "Defaulting to ${ver}"
@@ -390,7 +425,13 @@ determineTool() {
         exit 1
         fi
         name=$(<${godepsJSON} jq -r .ImportPath)
-        ver=${GOVERSION:-$(<${godepsJSON} jq -r .GoVersion)}
+
+        # Determine Go version from Godeps/Godeps.json if not already set by GOVERSION
+        if [ -z "${ver}" ]; then
+            ver=$(<${godepsJSON} jq -r .GoVersion)
+            go_version_origin="Godeps/Godeps.json"
+        fi
+
         warnGoVersionOverride
     elif [ -f "${vendorJSON}" ]; then
         TOOL="govendor"
@@ -409,10 +450,21 @@ determineTool() {
             err "For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration"
             exit 1
         fi
-        ver=${GOVERSION:-$(<${vendorJSON} jq -r .heroku.goVersion)}
+
+        # Determine Go version from vendor/vendor.json if not already set by GOVERSION
+        if [ -z "${ver}" ]; then
+            ver=$(<${vendorJSON} jq -r .heroku.goVersion)
+            if [ "${ver}" = "null" ] || [ -z "${ver}" ]; then
+                ver=${DefaultGoVersion}
+                go_version_origin="default"
+            else
+                go_version_origin="vendor/vendor.json"
+            fi
+        fi
+
         warnGoVersionOverride
-        if [ "${ver}" =  "null" -o -z "${ver}" ]; then
-            ver=${DefaultGoVersion}
+
+        if [ "${go_version_origin}" = "default" ]; then
             warn "The 'heroku.goVersion' field is not specified in 'vendor/vendor.json'."
             warn ""
             warn "Defaulting to ${ver}"


### PR DESCRIPTION
This PR adds `bin/report` to output structured build metadata for observability, tracking Go version resolution and dependency manager detection. Adapted from the [Python buildpack's implementation](https://github.com/heroku/heroku-buildpack-python/blob/8eaa83cf0f9e196abd13e895bc667274183909a6/bin/report).

_**Note:** Build data tracking is implemented directly within `determineTool()` to ensure metadata is captured even when the function exits early (e.g., validation errors). This lets `bin/report` provide observability data for failed builds, and shouldn't have any impact on the current logic/build output. While the existing logic could certainly be refactored and improved further, this approach should be sufficient for gathering usage data to inform the planned removal of deprecated tools (dep, godep, govendor, glide, gb) in favor of Go modules._

Depends on https://github.com/heroku/heroku-buildpack-go/pull/635

GUS-W-21257738

## Changes

### New Files

**`lib/build_data.sh`** - Adapted from [Python buildpack's `lib/build_data.sh`](https://github.com/heroku/heroku-buildpack-python/blob/8eaa83cf0f9e196abd13e895bc667274183909a6/lib/build_data.sh)
- Includes functions for storing strings, raw JSON, and durations
- Stores data in `${CACHE_DIR}/build-data/go.json`
- Preserves previous build data as `go-prev.json` (which we may want to use in the future for cache invalidation etc)

**`bin/report`** - Adapted from [Python buildpack's `bin/report`](https://github.com/heroku/heroku-buildpack-python/blob/8eaa83cf0f9e196abd13e895bc667274183909a6/bin/report)
- Outputs sorted JSON of all tracked build metadata
- Called by the build system after `bin/compile` (including on failures)

### Modified Files

**`bin/compile`**
- Initialize build data store at start
- Track expanded Go version and pinned status after `determineTool()`:
  - `go_version`: Resolved version after expansion (e.g., `go1.21.6`)
  - `go_version_pinned`: Whether version was fully specified (e.g., `go1.21.13` is pinned, `go1.21` is not)
- Removed duplicate `setGoVersionFromEnvironment()` function definition (now uses the one from `lib/common.sh`)

**`lib/common.sh`**
- Refactored `determineTool()` to track metadata as data is discovered:
  - `go_tool`: Package manager detected (`gomodules`, `dep`, `godep`, `govendor`, `glide`, `gb`)
  - `go_version_requested`: User-specified version before expansion (e.g., `go1.21`)
  - `go_version_origin`: Version source (e.g., `go.mod`, `GOVERSION`, `Gopkg.toml`, `default`)
- Check `GOVERSION` once at function start to avoid too much duplication
- Metadata captured even when function exits early (validation errors, etc.)
- Updated `setGoVersionFromEnvironment()` to track version metadata (used when `gb` or `glide` tools are detected)

**`Makefile`**
- Updated `run` target to execute (and print output from) `bin/report` after compile

**`.github/workflows/ci.yml`**
- Updated `container-test` job to also `make run` using a fixture that is expected to fail compile

## Example Output

The following examples show `bin/report` output from select test fixtures _(to test locally, run `make run FIXTURE=test/fixtures/<fixture>`)_:

### `mod-basic-go126`
Configuration: `go 1.26` in `go.mod`
```json
{
  "go_tool": "gomodules",
  "go_version": "go1.26.0",
  "go_version_origin": "go.mod",
  "go_version_pinned": false,
  "go_version_requested": "go1.26"
}
```

### `mod-basic-go126` with `GOVERSION` override
Configuration: `go 1.26` in `go.mod` + `GOVERSION=go1.20.13` env var

_Note: Shows `GOVERSION` taking precedence over `go.mod` and that `go_version_pinned` is true when specific/full version is pinned. Build fails (error: `cannot compile Go 1.26 code`)_

```json
{
  "go_tool": "gomodules",
  "go_version": "go1.20.13",
  "go_version_origin": "GOVERSION",
  "go_version_pinned": true,
  "go_version_requested": "go1.20.13"
}
```

### `mod-basic-go121`
Configuration: `// +heroku goVersion 1.21` in `go.mod`
```json
{
  "go_tool": "gomodules",
  "go_version": "go1.21.13",
  "go_version_origin": "go.mod (heroku comment)",
  "go_version_pinned": false,
  "go_version_requested": "1.21"
}
```

### `godep-basic-go17`
Configuration: `"GoVersion": "go1.7"` in `Godeps/Godeps.json`
```json
{
  "go_tool": "godep",
  "go_version": "go1.7.6",
  "go_version_origin": "Godeps/Godeps.json",
  "go_version_pinned": false,
  "go_version_requested": "go1.7"
}
```

### `mod-old-version`
Configuration: `// +heroku goVersion go1.10` in `go.mod`

_Note: Partial metadata (validation error during version resolution - Go modules requires `>= go1.11`)_
```json
{
  "go_tool": "gomodules",
  "go_version_origin": "go.mod (heroku comment)",
  "go_version_requested": "go1.10"
}
```

### `govendor-malformed`
Configuration: Invalid `vendor/vendor.json`

_Note: Partial metadata (validation error before version resolution)_
```json
{
  "go_tool": "govendor"
}
```