### PR TITLE
Add build duration metrics to `bin/report`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -20,6 +20,9 @@ source_stdlib
 # Set CACHE_DIR (used by build_data)
 CACHE_DIR="${cache_root}"
 source "${buildpack}/lib/build_data.sh"
+
+compile_start_time=$(build_data::current_unix_realtime)
+
 # Initialise the build data store used to track state across builds (for cache invalidation
 # and messaging when build configuration changes) and also so that `bin/report` can generate
 # a build report that will be consumed by the build system for observability.
@@ -758,3 +761,5 @@ echo "TOOL=${TOOL}" > "${t}"
 if [ "${TOOL}" != "gb" ]; then
     echo "NAME=${name}" >> "${t}"
 fi
+
+build_data::set_duration "total_duration" "${compile_start_time}"

--- a/bin/compile
+++ b/bin/compile
@@ -455,7 +455,9 @@ fi
 
 reportVer "${ver}"
 
+go_install_start_time=$(build_data::current_unix_realtime)
 ensureGo "${ver}"
+build_data::set_duration "go_install_duration" "${go_install_start_time}"
 
 mkdir -p "${build}/bin"
 

--- a/bin/compile
+++ b/bin/compile
@@ -505,6 +505,8 @@ setupProcfile() {
     info ""
 }
 
+dependencies_install_start_time=$(build_data::current_unix_realtime)
+
 case "${TOOL}" in
     gomodules)
         cd ${build}
@@ -702,6 +704,8 @@ esac
 
 installGolangMigrateIfWanted
 installMattesMigrateIfWanted
+
+build_data::set_duration "dependencies_install_duration" "${dependencies_install_start_time}"
 
 _newOrUpdatedBinFiles=$(binDiff)
 info ""


### PR DESCRIPTION
This PR adds duration metrics to `bin/report` for improved build performance observability:

- `total_duration`: Total compilation time from start to finish
- `go_install_duration`: Time to download and install the Go toolchain
- `dependencies_install_duration`: Time to fetch dependencies and build the application (includes dependency manager setup, hooks, and package compilation)

Adapted from the [Python buildpack's duration tracking approach](https://github.com/heroku/heroku-buildpack-python/blob/main/bin/compile).

## Example `bin/report` Output

```json
{
  "dependencies_install_duration": 10.899849,
  "go_install_duration": 5.298281,
  "go_tool": "gomodules",
  "go_version": "go1.26.0",
  "go_version_origin": "go.mod",
  "go_version_pinned": false,
  "go_version_requested": "go1.26",
  "total_duration": 16.67208
}
```

GUS-W-21287625