### PR TITLE
Switch to AWS' dual-stack S3 URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Changed S3 bucket URL to AWS' dual-stack (IPv6 compatible) endpoint
 
 ## [v223] - 2026-02-18
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -19,7 +19,7 @@ NC='\033[0m' # No Color
 CURL="curl --silent --show-error --location --fail --retry 15 --retry-delay 2 --retry-connrefused --connect-timeout 5" # retry for up to 30 seconds
 
 if [ -z "${GO_BUCKET_URL}" ]; then
-    BucketURL="https://heroku-golang-prod.s3.us-east-1.amazonaws.com"
+    BucketURL="https://heroku-golang-prod.s3.dualstack.us-east-1.amazonaws.com"
 else
     BucketURL="${GO_BUCKET_URL}"
 fi

--- a/sbin/fetch-test-assets
+++ b/sbin/fetch-test-assets
@@ -34,7 +34,7 @@ shaMatchesKnown() {
 
 checkMirror() {
     local filename="${1}"
-    local mirror_url="https://heroku-golang-prod.s3.us-east-1.amazonaws.com/${filename}"
+    local mirror_url="https://heroku-golang-prod.s3.dualstack.us-east-1.amazonaws.com/${filename}"
     local mirror_headers
     
     if ! mirror_headers=$(curl -sI -L --fail "${mirror_url}"); then


### PR DESCRIPTION
The default AWS S3 URLs only support IPv4, whereas the dual-stack URLs support both IPv4 and IPv6:
https://docs.aws.amazon.com/AmazonS3/latest/API/ipv6-access.html
https://docs.aws.amazon.com/AmazonS3/latest/API/dual-stack-endpoints.html

By switching to the dual-stack URLs, it means systems that support IPv6 will now use it instead of IPv4, which is helpful in IPv6 environments where IPv4 traffic has to fall back to being routed via NAT gateways (which has performance and ingress cost implications).

GUS-W-21336853