### PR TITLE
Improve CI performance with parallel test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           STACK: ${{ matrix.stack }}
       - name: Run tests
-        run: make -j 4 test-parallel STACK=${{ matrix.stack }}
+        run: make -j 6 test-parallel STACK=${{ matrix.stack }}
 
   container-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      # The images are pulled up front to prevent duplicate pulls due to the tests being run concurrently.
+      - name: Pull build image
+        run: docker pull "heroku/${STACK/-/:}-build"
+        env:
+          STACK: ${{ matrix.stack }}
       - name: Run tests
         run: make -j 4 test-parallel STACK=${{ matrix.stack }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           STACK: ${{ matrix.stack }}
       - name: Run tests
-        run: make -j 6 test-parallel STACK=${{ matrix.stack }}
+        run: make --jobs 6 test-parallel STACK=${{ matrix.stack }}
 
   container-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           STACK: ${{ matrix.stack }}
       - name: Run tests
-        run: make --jobs 6 test-parallel STACK=${{ matrix.stack }}
+        run: make --jobs 6 --output-sync=recurse test-parallel STACK=${{ matrix.stack }}
 
   container-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Run tests
-        run: make test STACK=${{ matrix.stack }}
+        run: make -j 4 test-parallel STACK=${{ matrix.stack }}
 
   container-test:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@ TEST_NAMES := $(shell grep -oE '^test[a-zA-Z0-9_]+' test/run.sh)
 TEST_TARGETS := $(addprefix run-test-, $(TEST_NAMES))
 endif
 
-# Run all tests in parallel via `make -j N test-parallel`. Each test runs in its own container for full isolation.
+# Run all tests in parallel via `make --jobs N --output-sync=recurse test-parallel`.
+# Each test runs in its own container for full isolation.
 test-parallel: $(TEST_TARGETS)
 	@printf "\nAll %d tests passed!\n" $(words $(TEST_TARGETS))
 
-# Wrapper that runs a single test and buffers its output (so parallel test output doesn't interleave).
+# Wrapper that runs a single test and captures its output for printing as a block.
+# Use `--output-sync=recurse` to prevent interleaving across parallel jobs.
 run-test-%:
 	@output=$$($(MAKE) --no-print-directory test STACK="$(STACK)" TEST="$*" 2>&1); \
 	status=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 		'
 	@echo
 
-ifeq ($(MAKELEVEL),0)
+ifneq ($(filter test-parallel,$(MAKECMDGOALS)),)
 TEST_NAMES := $(shell grep -oE '^test[a-zA-Z0-9_]+' test/run.sh)
 TEST_TARGETS := $(addprefix run-test-, $(TEST_NAMES))
 endif

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ test:
 		bash -euo pipefail -O dotglob -c '\
 			cd /src; \
 			test/run.sh $(if $(TEST),-- "$(TEST)"); \
-			echo -e "\nTest run was successful!"; \
 		'
-	@echo
 
 ifneq ($(filter test-parallel,$(MAKECMDGOALS)),)
 TEST_NAMES := $(shell grep -oE '^test[a-zA-Z0-9_]+' test/run.sh)

--- a/Makefile
+++ b/Makefile
@@ -18,14 +18,17 @@ test:
 			test/run.sh $(if $(TEST),-- "$(TEST)"); \
 		'
 
+# Extract test function names from test/run.sh when test-parallel is invoked.
 ifneq ($(filter test-parallel,$(MAKECMDGOALS)),)
 TEST_NAMES := $(shell grep -oE '^test[a-zA-Z0-9_]+' test/run.sh)
 TEST_TARGETS := $(addprefix run-test-, $(TEST_NAMES))
 endif
 
+# Run all tests in parallel via `make -j N test-parallel`. Each test runs in its own container for full isolation.
 test-parallel: $(TEST_TARGETS)
 	@printf "\nAll %d tests passed!\n" $(words $(TEST_TARGETS))
 
+# Wrapper that runs a single test and buffers its output (so parallel test output doesn't interleave).
 run-test-%:
 	@output=$$($(MAKE) --no-print-directory test STACK="$(STACK)" TEST="$*" 2>&1); \
 	status=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ TEST_TARGETS := $(addprefix run-test-, $(TEST_NAMES))
 endif
 
 test-parallel: $(TEST_TARGETS)
-	@printf "\nAll tests passed!\n"
+	@printf "\nAll %d tests passed!\n" $(words $(TEST_TARGETS))
 
 run-test-%:
 	@output=$$($(MAKE) --no-print-directory test STACK="$(STACK)" TEST="$*" 2>&1); \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test run run-ci publish
+.PHONY: test test-parallel run run-ci publish
 
 STACK ?= heroku-24
 FIXTURE ?= test/fixtures/mod-basic-go126
@@ -19,6 +19,20 @@ test:
 			echo -e "\nTest run was successful!"; \
 		'
 	@echo
+
+ifeq ($(MAKELEVEL),0)
+TEST_NAMES := $(shell grep -oE '^test[a-zA-Z0-9_]+' test/run.sh)
+TEST_TARGETS := $(addprefix run-test-, $(TEST_NAMES))
+endif
+
+test-parallel: $(TEST_TARGETS)
+	@printf "\nAll tests passed!\n"
+
+run-test-%:
+	@output=$$($(MAKE) --no-print-directory test STACK="$(STACK)" TEST="$*" 2>&1); \
+	status=$$?; \
+	printf "\n--- %s ---\n%s\n" "$*" "$$output"; \
+	exit $$status
 
 publish:
 	@bash sbin/publish.sh


### PR DESCRIPTION
The integration test suite uses `shunit2`, which doesn't support parallel test execution out of the box. Running tests sequentially takes almost 10 minutes locally (using `make test`), with most time spent on I/O (Docker startup, downloading Go tarballs, packages, etc from upstream - with download rates that can be highly variable at times, frequently adding several minutes to individual test runs).

This PR adds a `make test-parallel` target that extracts test function names from `test/run.sh` and generates a Make prerequisite target for each one. Using Make's built-in `-j` flag, these targets run concurrently - each in its own Docker container using the existing `make test TEST=<name>` target. This gives full isolation (separate filesystem, git config, temp dirs) without needing to rework the test infrastructure to support in-process parallelism.

The per-test container overhead is relatively modest and well worth the tradeoff: Local test execution times drops to 2-2.5 minutes with `make -j 6 test-parallel`, approximately 4x faster than `make test`. GHA CI execution times improvements are a bit more modest at around ~3.5 minutes (based on a few test runs while working on this PR), which is still ~2.5-3x faster.

### Changes

- Add `test-parallel` target using Make's built-in `-j` parallelism and per-test `run-test-%` wrapper targets
- Buffer output per test in `run-test-%` to prevent interleaving
- Update CI workflow to use `make -j 6 test-parallel` and pull Docker images upfront to avoid concurrent pulls
- Clean up redundant `test` target output

GUS-W-21497042