### PR TITLE
Improve `curl` download resilience and timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Fetch Go binaries directly from upstream sources instead of S3 mirror
+* Improve curl download resilience and timeouts
 
 ## [v225] - 2026-03-10
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -12,7 +12,11 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 RED='\033[1;31m'
 NC='\033[0m' # No Color
-CURL="curl --silent --show-error --location --fail --retry 15 --retry-delay 2 --retry-connrefused --connect-timeout 5" # retry for up to 30 seconds
+# We use --max-time/--retry-max-time for improved UX and metrics for hanging downloads compared to
+# seconds relying on the build system timeout. Go tarballs are up to ~70 MB and typically download in a few
+# seconds on Heroku, so we set relatively low timeouts to reduce delays before retries.
+# We use --no-progress-meter rather than --silent so that retry status messages are printed.
+CURL="curl --no-progress-meter --location --fail --max-time 150 --retry-max-time 150 --retry 5 --retry-connrefused --connect-timeout 5"
 
 TOOL=""
 # Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile


### PR DESCRIPTION
We've observed that downloads from go.dev can occasionally have highly variable speeds, which is more likely to affect builds since fetching artifacts from upstream instead of an S3 mirror bucket (#647). This PR updates our `curl` configuration to better handle these conditions.

### Changes

- Replace `--silent --show-error` with `--no-progress-meter` so that curl retry status messages are visible in build output
- Add `--max-time` and `--retry-max-time` to cap individual request and total retry duration, improving UX for hanging downloads compared to relying on the build system timeout
- Reduce retry count from 15 (with fixed 2s delay) to 5 retries with a time-based budget

GUS-W-21524382