### PR TITLE
Adjust curl retry max-time settings to handle transient failures

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -16,7 +16,7 @@ NC='\033[0m' # No Color
 # seconds relying on the build system timeout. Go tarballs are up to ~70 MB and typically download in a few
 # seconds on Heroku, so we set relatively low timeouts to reduce delays before retries.
 # We use --no-progress-meter rather than --silent so that retry status messages are printed.
-CURL="curl --no-progress-meter --location --fail --max-time 150 --retry-max-time 150 --retry 5 --retry-connrefused --connect-timeout 5"
+CURL="curl --no-progress-meter --location --fail --max-time 150 --retry-max-time 350 --retry 5 --retry-connrefused --connect-timeout 5"
 
 TOOL=""
 # Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -16,7 +16,7 @@ NC='\033[0m' # No Color
 # seconds relying on the build system timeout. Go tarballs are up to ~70 MB and typically download in a few
 # seconds on Heroku, so we set relatively low timeouts to reduce delays before retries.
 # We use --no-progress-meter rather than --silent so that retry status messages are printed.
-CURL="curl --no-progress-meter --location --fail --max-time 150 --retry-max-time 350 --retry 5 --retry-connrefused --connect-timeout 5"
+CURL="curl --no-progress-meter --location --fail --max-time 30 --retry-max-time 200 --retry 5 --retry-connrefused --connect-timeout 5"
 
 TOOL=""
 # Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -119,7 +119,7 @@ downloadFile() {
     pushd "${targetDir}" &> /dev/null
         start "Fetching ${fileName}"
             local url="$(<"${FilesJSON}" jq -r '."'${fileName}'".URL')"
-            ${CURL} -o "${fileName}" "${url}"
+            ${CURL} -o "${fileName}" "${url}" 2>&1
             if [ -n "${xCmd}" ]; then
                 ${xCmd} ${targetFile}
             fi


### PR DESCRIPTION
We've observed intermittent 502 errors and slow transfers when downloading Go binaries from `dl.google.com`. With `--retry-max-time` set to the same value as `--max-time` (150s), a single slow retry that hits the per-request timeout exhausts the entire retry budget, leaving no room for subsequent attempts.

This PR increases `--retry-max-time` from 200s, which provides enough budget for 4 file slow downloads that each hit the decreased 30s `--max-time` limit, while still leaving room for a successful retry under normal conditions (~2-3s) after default exponential backoff.

GUS-W-21524382