### PR TITLE
Clean up build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fetch Go binaries directly from upstream sources instead of S3 mirror
 * Improve curl download resilience and timeouts
+* Clean up build output with structured formatting and consistent indentation
 
 ## [v225] - 2026-03-10
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ snapshotBinBefore
 # Clean up old cache files if migrating from old cache structure.
 # We detect this legacy structure by looking for 'go-path' in the root.
 if [ -d "${cache_root}/go-path" ] && [ ! -d "${cache}/go-path" ]; then
-    step "Clearing old build cache artifacts"
+    output::step "Clearing old build cache artifacts"
 
     # Remove artifacts that were previously stored in the cache root
     rm -rf "${cache_root}"/go[0-9]* \
@@ -53,11 +53,13 @@ DefaultGoVersion="$(<${DataJSON} jq -r '.Go.DefaultVersion')"
 
 handleDefaultPkgSpec() {
     if [ "${pkgs}" = "default" ]; then
-        warn "Installing package '.' (default)"
-        warn ""
-        warn "To install a different package spec add a comment in the following form to your \`go.mod\` file:"
-        warn "// +heroku install ./cmd/..."
-        warn ""
+        output::warning <<-EOF
+			Installing package '.' (default)
+
+			To install a different package spec add a comment in the
+			following form to your go.mod file:
+			// +heroku install ./cmd/...
+		EOF
         pkgs="."
     fi
 }
@@ -81,13 +83,13 @@ reportVer() {
     local ver="${1}"
     case $ver in
         devel*)
-            warn ""
-            warn "You are using a development build of Go."
-            warn "This is provided for users requiring an unreleased Go version"
-            warn "but is otherwise unsupported."
-            warn ""
-            warn "Build tests are NOT RUN!!"
-            warn ""
+            output::warning <<-EOF
+				You are using a development build of Go.
+				This is provided for users requiring an unreleased Go version
+				but is otherwise unsupported.
+
+				Build tests are NOT RUN!!
+			EOF
         ;;
     esac
 }
@@ -98,10 +100,10 @@ ensureGo() {
     local goFile=""
     local txt="Installing ${goVersion}"
     if [ -d "${goPath}" ]; then
-        step "Using ${goVersion}"
+        output::step "Using ${goVersion}"
     else
         #For a go version change, we delete everything in our namespace
-        step "New Go Version, clearing old cache"
+        output::step "New Go Version, clearing old cache"
         if [ -d "${cache}/go-path" ]; then
             find "${cache}/go-path" ! -perm -u=w -print0 | xargs -r -0 chmod u+w 2>&1
         fi
@@ -121,7 +123,7 @@ ensureGo() {
             ;;
         esac
 
-        step "${txt}"
+        output::step "${txt}"
         ensureFile "${goFile}" "${goPath}" "tar -C ${goPath} --strip-components=1 -zxf"
         rm -f "${goPath}/${goFile}"
 
@@ -132,11 +134,10 @@ ensureGo() {
                     pushd "${goVersion}" &> /dev/null
                         local sha=$(echo ${goVersion} | cut -d - -f 2)  #assumes devel-<short sha> or devel-<full sha>
                         local url="https://github.com/golang/go/archive/$sha.tar.gz"
-                        start "Downloading development Go version ${goVersion}"
+                        output::step "Downloading development Go version ${goVersion}"
                             ${CURL} ${url} | tar zxf -
                             mv go-${sha}* go
-                        finished
-                        step "Compiling development Go version ${goVersion}"
+                        output::step "Compiling development Go version ${goVersion}"
                         pushd go/src &> /dev/null
                             echo "devel +${sha} $(date "+%a %b %H:%M:%S %G %z")"> ../VERSION
                             GOROOT_BOOTSTRAP=$(pushd ${cache}/${bGoVersion}/go > /dev/null; pwd; popd > /dev/null) ./make.bash 2>&1
@@ -163,29 +164,31 @@ ensureGo() {
 
 warnGoVersionOverride() {
     if [ ! -z "${GOVERSION}" ]; then
-        warn "Using \$GOVERSION override."
-        warn "     \$GOVERSION = ${GOVERSION}"
-        warn ""
-        warn "If this isn't what you want please run:'"
-        warn "  heroku config:unset GOVERSION -a <app>"
-        warn ""
+        output::warning <<-EOF
+			Using \$GOVERSION override.
+			\$GOVERSION = ${GOVERSION}
+
+			If this isn't what you want please run:
+			heroku config:unset GOVERSION -a <app>
+		EOF
     fi
 }
 
 warnPackageSpecOverride() {
     if [ ! -z "${GO_INSTALL_PACKAGE_SPEC}" ]; then
-        warn "Using \$GO_INSTALL_PACKAGE_SPEC override."
-        warn "     \$GO_INSTALL_PACKAGE_SPEC = ${GO_INSTALL_PACKAGE_SPEC}"
-        warn ""
-        warn "If this isn't what you want please run:'"
-        warn "  heroku config:unset GO_INSTALL_PACKAGE_SPEC -a <app>"
-        warn ""
+        output::warning <<-EOF
+			Using \$GO_INSTALL_PACKAGE_SPEC override.
+			\$GO_INSTALL_PACKAGE_SPEC = ${GO_INSTALL_PACKAGE_SPEC}
+
+			If this isn't what you want please run:
+			heroku config:unset GO_INSTALL_PACKAGE_SPEC -a <app>
+		EOF
     fi
 }
 
 installPkgs() {
-    step "Running: go install -v ${FLAGS[@]} ${pkgs}"
-    go install -v "${FLAGS[@]}" ${pkgs} 2>&1
+    output::step "Running: go install -v ${FLAGS[*]} ${pkgs}"
+    go install -v "${FLAGS[@]}" ${pkgs} 2>&1 | output::indent
 }
 
 loadEnvDir "${env_dir}"
@@ -217,9 +220,9 @@ if [ -n "${GO_LINKER_SYMBOL}" -a -n "${GO_LINKER_VALUE}" ]; then
 fi
 
 if [ -e "${build}/bin" -a ! -d "${build}/bin" ]; then
-    err ""
-    err "File bin exists and is not a directory."
-    err ""
+    output::error <<-EOF
+		Error: File bin exists and is not a directory.
+	EOF
     exit 1
 fi
 
@@ -254,22 +257,22 @@ setupProcfile() {
     if [ ${#pf} -eq 0 ]; then
         return
     fi
-    info ""
-    info "Created a Procfile with the following entries:"
+    output::step "Created a Procfile with the following entries:"
     if [ ${#pf[@]} -eq 1 ]; then
         local line="web: bin/$(echo ${pf[0]} | cut -d / -f 2)"
         echo "${line}" > ${build}/Procfile
-        info "\t\t${line}"
+        echo "${line}" | output::indent
     elif [ ${#pf[@]} -gt 1 ]; then
         for pfl in "${pf[@]}"; do
             echo "${pfl}" >> ${build}/Procfile
-            info "\t\t${pfl}"
+            echo "${pfl}" | output::indent
         done
     fi
-    info ""
-    info "If these entries look incomplete or incorrect please create a Procfile with the required entries."
-    info "See https://devcenter.heroku.com/articles/procfile for more details about Procfiles"
-    info ""
+    output::notice <<-EOF
+		If these entries look incomplete or incorrect please create a
+		Procfile with the required entries.
+		See https://devcenter.heroku.com/articles/procfile for more details about Procfiles
+	EOF
 }
 
 dependencies_install_start_time=$(build_data::current_unix_realtime)
@@ -292,24 +295,22 @@ if [ -d "${build}/vendor" -a -s "${build}/go.sum" ]; then
     FLAGS+=(-mod=vendor)
 fi
 
-step "Determining packages to install"
+output::step "Determining packages to install"
 pkgs=${GO_INSTALL_PACKAGE_SPEC:-$(awk '{ if ($1 == "//" && $2 == "+heroku" && $3 == "install" ) { print substr($0, index($0,$4)); exit }}' ${goMOD})}
 if [ -z "${pkgs}" ]; then
     pkgs=$(mainPackagesInModule)
     if [ -z "${pkgs}" ]; then
-        warn ""
-        warn "No main packages found in module ${name}"
-        warn ""
-        warn "Unsure what package(s) to install, defaulting to '.'"
-        warn ""
+        output::warning <<-EOF
+			No main packages found in module ${name}
+
+			Unsure what package(s) to install, defaulting to '.'
+		EOF
         pkgs="default"
     else
-        info ""
-        info "Detected the following main packages to install:"
+        output::step "Detected the following main packages to install:"
         for pkg in ${pkgs}; do
-            info "\t\t${pkg}"
+            echo "${pkg}" | output::indent
         done
-        info ""
     fi
 fi
 
@@ -318,26 +319,25 @@ handleDefaultPkgSpec
 
 unset GIT_DIR # unset git dir or it will mess with goinstall
 if [[ -f bin/go-pre-compile ]]; then
-    step "Running bin/go-pre-compile hook"
+    output::step "Running bin/go-pre-compile hook"
     chmod a+x bin/go-pre-compile
-    bin/go-pre-compile
+    bin/go-pre-compile 2>&1 | output::indent
 fi
 
 installPkgs
 
 if [[ -f bin/go-post-compile ]]; then
-    step "Running bin/go-post-compile hook"
+    output::step "Running bin/go-post-compile hook"
     chmod a+x bin/go-post-compile
-    bin/go-post-compile
+    bin/go-post-compile 2>&1 | output::indent
 fi
 
 build_data::set_duration "dependencies_install_duration" "${dependencies_install_start_time}"
 
 _newOrUpdatedBinFiles=$(binDiff)
-info ""
-info "Installed the following binaries:"
+output::step "Installed the following binaries:"
 for fyle in ${_newOrUpdatedBinFiles}; do
-  info "\t\t${fyle}"
+  echo "${fyle}" | output::indent
 done
 
 setupProcfile
@@ -347,12 +347,11 @@ mkdir -p $build/.profile.d
 echo 'PATH=$PATH:$HOME/bin' > $build/.profile.d/go.sh
 
 if [ "${GO_INSTALL_TOOLS_IN_IMAGE}" = "true" ]; then
-    start "Copying go tool chain to \$GOROOT=\$HOME/.heroku/go"
-        mkdir -p "${build}/.heroku/go"
-        cp -a "${GOROOT}/"* "${build}/.heroku/go"
-        echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
-        echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
-    finished
+    output::step "Copying go tool chain to \$GOROOT=\$HOME/.heroku/go"
+    mkdir -p "${build}/.heroku/go"
+    cp -a "${GOROOT}/"* "${build}/.heroku/go"
+    echo 'export GOROOT=$HOME/.heroku/go' > "${build}/.profile.d/goroot.sh"
+    echo 'PATH=$PATH:$GOROOT/bin' >> "${build}/.profile.d/goroot.sh"
 fi
 
 t="${build}/.heroku/go"

--- a/bin/compile
+++ b/bin/compile
@@ -238,7 +238,9 @@ export GOPATH
 
 mainPackagesInModule() {
   # For an explanation of what this is doing, see https://dave.cheney.net/2014/09/14/go-list-your-swiss-army-knife
-  go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./...
+  # Stderr (module download progress) is indented and redirected back to stderr so it displays
+  # neatly under the current step without being captured into the command substitution's stdout.
+  go list -find "${FLAGS[@]}" -f '{{ if eq .Name "main" }} {{.ImportPath}} {{ end }}' ./... 2> >(output::indent >&2)
 }
 
 setupProcfile() {

--- a/bin/detect
+++ b/bin/detect
@@ -19,34 +19,30 @@ if test -f "${build}/go.mod" || #go modules
 then
   echo Go
 else
-  {
-    cat <<EOF
-Error: Your app is configured to use the Go buildpack,
-but we couldn't find a go.mod file.
+  output::error <<-EOF
+	Error: Your app is configured to use the Go buildpack,
+	but we couldn't find a go.mod file.
 
-A Go app on Heroku must have a 'go.mod' file in the root
-directory of its source code.
+	A Go app on Heroku must have a 'go.mod' file in the root
+	directory of its source code.
 
-Currently the root directory of your app contains:
+	Currently the root directory of your app contains:
 
-$(ls -1A --indicator-style=slash "${build}" || true)
+	$(ls -1A --indicator-style=slash "${build}" || true)
 
-If your app already has a go.mod file, check that it:
+	If your app already has a go.mod file, check that it:
 
-1. Is in the top level directory (not a subdirectory).
-2. Has the correct spelling (the filenames are case-sensitive).
-3. Isn't listed in '.gitignore' or '.slugignore'.
-4. Has been added to Git using 'git add go.mod' and committed.
+	1. Is in the top level directory (not a subdirectory).
+	2. Has the correct spelling (the filenames are case-sensitive).
+	3. Isn't listed in '.gitignore' or '.slugignore'.
+	4. Has been added to Git using 'git add go.mod' and committed.
 
-To create a go.mod file, run 'go mod init <module-name>' in your
-project directory.
+	To create a go.mod file, run 'go mod init <module-name>' in your
+	project directory.
 
-For help with using Go on Heroku, see:
-https://devcenter.heroku.com/articles/getting-started-with-go
-https://devcenter.heroku.com/articles/go-support
-EOF
-  } | while IFS= read -r line; do
-    err "${line}"
-  done
+	For help with using Go on Heroku, see:
+	https://devcenter.heroku.com/articles/getting-started-with-go
+	https://devcenter.heroku.com/articles/go-support
+	EOF
   exit 1
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -5,7 +5,7 @@ set -e
 build=$(cd "$1/" && pwd)
 buildpack=$(cd "$(dirname $0)/.." && pwd)
 
-source "${buildpack}/lib/common.sh"
+source "${buildpack}/lib/output.sh"
 
 # Detect go.mod (supported) and legacy dependency manager files (unsupported,
 # but we still want to pass detection so that bin/compile can provide a helpful

--- a/bin/test
+++ b/bin/test
@@ -64,5 +64,5 @@ if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
 fi
 
 output::step "Standard (Non TAP) test output"
-cat "${output}" | output::indent
+output::indent < "${output}"
 output::step "Finished"

--- a/bin/test
+++ b/bin/test
@@ -54,6 +54,7 @@ else
 fi
 output::step "Running Tests With: go test ${_tflags[*]} ./... | patter"
 go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter
+echo
 if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
     _tflags=("${_tflags[@]:1}") # push -race off
     _tflags+=("-run=_")

--- a/bin/test
+++ b/bin/test
@@ -43,8 +43,8 @@ output=$(mktemp)
 
 cd "${build}"
 if [ -f "${build}/.golangci.yml" -o -f "${build}/.golangci.toml" -o -f "${build}/.golangci.json" ]; then
-    step "Running: golangci-lint -v --build-tags heroku run"
-    ${build}/.heroku/golangci/bin/golangci-lint -v --build-tags heroku run 2>&1
+    output::step "Running: golangci-lint -v --build-tags heroku run"
+    ${build}/.heroku/golangci/bin/golangci-lint -v --build-tags heroku run 2>&1 | output::indent
 fi
 _tflags=("-race" "-v")
 if [ -s "./go.sum" -a -d "./vendor" ]; then
@@ -52,21 +52,17 @@ if [ -s "./go.sum" -a -d "./vendor" ]; then
 else
   _tflags+=("-mod=readonly")
 fi
-step "Running Tests With: go test ${_tflags[@]} ./... | patter"
-go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter
-step
+output::step "Running Tests With: go test ${_tflags[*]} ./... | patter"
+go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter | output::indent
 if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
     _tflags=("${_tflags[@]:1}") # push -race off
     _tflags+=("-run=_")
     _tflags+=("-bench=.")
     _tflags+=("-benchmem")
-    step "Running Benchmarks With: go test ${_tflags[@]} ./..."
-    go test ${_tflags[@]} ./... 2>&1
+    output::step "Running Benchmarks With: go test ${_tflags[*]} ./..."
+    go test ${_tflags[@]} ./... 2>&1 | output::indent
 fi
 
-step
-step "Standard (Non TAP) test output"
-cat "${output}"
-step
-step "Finished"
-step
+output::step "Standard (Non TAP) test output"
+cat "${output}" | output::indent
+output::step "Finished"

--- a/bin/test
+++ b/bin/test
@@ -53,7 +53,7 @@ else
   _tflags+=("-mod=readonly")
 fi
 output::step "Running Tests With: go test ${_tflags[*]} ./... | patter"
-go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter | output::indent
+go test ${_tflags[@]} ./... 2>&1 | tee -a ${output} | patter
 if [[ -z "${GO_TEST_SKIP_BENCHMARK}" ]]; then
     _tflags=("${_tflags[@]:1}") # push -race off
     _tflags+=("-run=_")

--- a/bin/test-compile
+++ b/bin/test-compile
@@ -14,7 +14,7 @@ buildpack="${testpack}"
 source ${testpack}/bin/compile "${build}" "${cache}" "${env_dir}"
 
 if [ -f "${build}/.golangci.yml" -o -f "${build}/.golangci.toml" -o -f "${build}/.golangci.json" ]; then
-    step "/.golangci.{yml,toml,json} detected"
+    output::step "/.golangci.{yml,toml,json} detected"
     tmp="$(mktemp -d)"
     mkdir -p "${build}/.heroku/golangci/bin"
     ensureFile "golangci-lint-1.20.0-linux-amd64.tar.gz" "${tmp}" "tar -C ${build}/.heroku/golangci/bin --strip-components=1 -zxf"

--- a/lib/build_data.sh
+++ b/lib/build_data.sh
@@ -105,14 +105,16 @@ function build_data::_set() {
 		new_data_file_contents="$(jq --exit-status --arg key "${key}" "${jq_args[@]}" '. + { ($key): ($value) }' "${BUILD_DATA_FILE}")"
 		echo "${new_data_file_contents}" >"${BUILD_DATA_FILE}"
 	else
-		err "Error: Can't find the buildpack's build data file."
-        err ""
-		err "The Go buildpack's internal build data file is missing:"
-        err "${BUILD_DATA_FILE}"
-        err ""
-		err "This file is required for the buildpack to work correctly,"
-		err "and so you must not delete it when removing files from the"
-		err "build cache or /tmp directories."
+		output::error <<-EOF
+			Error: Can't find the buildpack's build data file.
+
+			The Go buildpack's internal build data file is missing:
+			${BUILD_DATA_FILE}
+
+			This file is required for the buildpack to work correctly,
+			and so you must not delete it when removing files from the
+			build cache or /tmp directories.
+		EOF
 		build_data::setup
 		build_data::set_string "failure_reason" "build-data::data-file-deleted"
 		exit 1

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -7,11 +7,7 @@ DataJSON="${buildpack}/data.json"
 FilesJSON="${buildpack}/files.json"
 goMOD="${build}/go.mod"
 
-steptxt="----->"
-GREEN='\033[1;32m'
-YELLOW='\033[1;33m'
-RED='\033[1;31m'
-NC='\033[0m' # No Color
+source "$(dirname "${BASH_SOURCE[0]}")/output.sh"
 # We use --max-time/--retry-max-time for improved UX and metrics for hanging downloads compared to
 # seconds relying on the build system timeout. Go tarballs are up to ~70 MB and typically download in a few
 # seconds on Heroku, so we set relatively low timeouts to reduce delays before retries.
@@ -65,29 +61,6 @@ binDiff() {
   echo ${new[@]}
 }
 
-info() {
-    echo -e "${GREEN}       $@${NC}"
-}
-
-warn() {
-    echo -e "${YELLOW} !!    $@${NC}"
-}
-
-err() {
-    echo -e >&2 "${RED} !!    $@${NC}"
-}
-
-step() {
-    echo "$steptxt $@"
-}
-
-start() {
-    echo -n "$steptxt $@... "
-}
-
-finished() {
-    echo "done"
-}
 
 knownFile() {
     local fileName="${1}"
@@ -98,16 +71,16 @@ downloadFile() {
     local fileName="${1}"
 
     if ! knownFile ${fileName}; then
-        err ""
-        err "The requested file (${fileName}) is unknown to the buildpack!"
-        err ""
-        err "The buildpack tracks and validates the SHA256 sums of the files"
-        err "it uses. Because the buildpack doesn't know about the file"
-        err "it likely won't be able to obtain a copy and validate the SHA."
-        err ""
-        err "To find out more info about this error please visit:"
-        err "    https://devcenter.heroku.com/articles/unknown-go-buildack-files"
-        err ""
+        output::error <<-EOF
+			Error: The requested file (${fileName}) is unknown to the buildpack!
+
+			The buildpack tracks and validates the SHA256 sums of the files
+			it uses. Because the buildpack doesn't know about the file
+			it likely won't be able to obtain a copy and validate the SHA.
+
+			To find out more info about this error please visit:
+			https://devcenter.heroku.com/articles/unknown-go-buildack-files
+		EOF
         exit 1
     fi
 
@@ -117,20 +90,20 @@ downloadFile() {
 
     mkdir -p "${targetDir}"
     pushd "${targetDir}" &> /dev/null
-        start "Fetching ${fileName}"
+        output::step "Fetching ${fileName}"
             local url="$(<"${FilesJSON}" jq -r '."'${fileName}'".URL')"
             ${CURL} -o "${fileName}" "${url}" 2>&1
             if ! SHAValid "${fileName}" "${targetFile}"; then
-                err ""
-                err "Downloaded file (${fileName}) sha does not match recorded SHA"
-                err "Unable to continue."
-                err ""
+                output::error <<-EOF
+					Error: Downloaded file (${fileName}) SHA does not match recorded SHA.
+
+					Unable to continue.
+				EOF
                 exit 1
             fi
             if [ -n "${xCmd}" ]; then
-                ${xCmd} ${targetFile}
+                ${xCmd} ${targetFile} 2>&1 | output::indent
             fi
-        finished
     popd &> /dev/null
 }
 
@@ -295,9 +268,7 @@ determineTool() {
         TOOL="gomodules"
         build_data::set_string "go_tool" "${TOOL}"
 
-        step ""
-        info "Detected go modules via go.mod"
-        step ""
+        output::step "Detected go modules via go.mod"
 
         # Determine Go version from go.mod if not already set by GOVERSION
         if [ -z "${ver}" ]; then
@@ -318,28 +289,32 @@ determineTool() {
         fi
 
         name=$(awk '{ if ($1 == "module" ) { gsub(/"/, "", $2); print $2; exit } }' < ${goMOD})
-        info "Detected Module Name: ${name}"
-        step ""
+        output::step "Detected Module Name: ${name}"
         warnGoVersionOverride
 
         if [ "${go_version_origin}" = "default" ]; then
-            warn "The go.mod file for this project does not specify a Go version"
-            warn ""
-            warn "Defaulting to ${ver}"
-            warn ""
-            warn "For more details see: https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration"
-            warn ""
+            output::warning <<-EOF
+				The go.mod file for this project does not specify a Go version.
+
+				Defaulting to ${ver}
+
+				For more details see:
+				https://devcenter.heroku.com/articles/go-apps-with-modules#build-configuration
+			EOF
         fi
 
         if supportsGoModules "${ver}"; then
-            err "You are using ${ver}, which does not support Go modules"
-            err ""
-            err "Go modules are supported by go1.11 and above."
-            err ""
-            err "Please add/update the comment in your go.mod file to specify a Go version >= go1.11 like so:"
-            err "// +heroku goVersion ${DefaultGoVersion}"
-            err ""
-            err "Then commit and push again."
+            output::error <<-EOF
+				Error: You are using ${ver}, which does not support Go modules.
+
+				Go modules are supported by go1.11 and above.
+
+				Please add/update the comment in your go.mod file to specify
+				a Go version >= go1.11 like so:
+				// +heroku goVersion ${DefaultGoVersion}
+
+				Then commit and push again.
+			EOF
             exit 1
         fi
     else
@@ -358,22 +333,26 @@ determineTool() {
 
         if [ -n "${legacy_tool}" ]; then
             build_data::set_string "go_tool" "${legacy_tool}"
-            err "Your app appears to use '${legacy_tool}' for dependency management,"
-            err "but support for ${legacy_tool} has been removed."
-            err ""
-            err "Go modules (go.mod) is now the only supported dependency"
-            err "management solution on Heroku."
-            err ""
-            err "To migrate, run 'go mod init <module-name>' in your project"
-            err "directory and commit the resulting go.mod file."
-            err ""
-            err "For more details see:"
-            err "https://devcenter.heroku.com/articles/go-modules"
+            output::error <<-EOF
+				Error: Your app appears to use '${legacy_tool}' for dependency management,
+				but support for ${legacy_tool} has been removed.
+
+				Go modules (go.mod) is now the only supported dependency
+				management solution on Heroku.
+
+				To migrate, run 'go mod init <module-name>' in your project
+				directory and commit the resulting go.mod file.
+
+				For more details see:
+				https://devcenter.heroku.com/articles/go-modules
+			EOF
         else
-            err "A go.mod file is required."
-            err ""
-            err "For help with using Go on Heroku, see:"
-            err "https://devcenter.heroku.com/articles/go-support"
+            output::error <<-EOF
+				Error: A go.mod file is required.
+
+				For help with using Go on Heroku, see:
+				https://devcenter.heroku.com/articles/go-support
+			EOF
         fi
         exit 1
     fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -92,7 +92,7 @@ downloadFile() {
     pushd "${targetDir}" &> /dev/null
         output::step "Fetching ${fileName}"
             local url="$(<"${FilesJSON}" jq -r '."'${fileName}'".URL')"
-            ${CURL} -o "${fileName}" "${url}" 2>&1
+            ${CURL} -o "${fileName}" "${url}" 2>&1 | output::indent
             if ! SHAValid "${fileName}" "${targetFile}"; then
                 output::error <<-EOF
 					Error: Downloaded file (${fileName}) SHA does not match recorded SHA.

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -eo pipefail
+
+ANSI_BLUE=$'\e[1;34m'
+ANSI_RED=$'\e[1;31m'
+ANSI_YELLOW=$'\e[1;33m'
+ANSI_RESET=$'\e[0m'
+
+# Output a single line step message to stdout.
+#
+# Usage:
+# ```
+# output::step "Installing Python ..."
+# ```
+function output::step() {
+	echo "-----> ${1}"
+}
+
+# Indent passed stdout. Typically used to indent command output within a step.
+#
+# Usage:
+# ```
+# pip install ... |& output::indent
+# ```
+function output::indent() {
+	sed --unbuffered "s/^/       /"
+}
+
+# Output a styled multi-line notice message to stderr.
+#
+# Usage:
+# ```
+# output::notice <<-EOF
+# 	Note: The note summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::notice() {
+	echo >&2
+	sed --expression "s/^/${ANSI_BLUE} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}
+
+# Output a styled multi-line warning message to stderr.
+#
+# Usage:
+# ```
+# output::warning <<-EOF
+# 	Warning: The warning summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::warning() {
+	echo >&2
+	sed --expression "s/^/${ANSI_YELLOW} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}
+
+# Output a styled multi-line error message to stderr.
+#
+# Usage:
+# ```
+# output::error <<-EOF
+# 	Error: The error summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::error() {
+	echo >&2
+	sed --expression "s/^/${ANSI_RED} !     /" --expression "s/$/${ANSI_RESET}/" >&2
+	echo >&2
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -5,7 +5,7 @@ testTestPackModulesVendoredGolangLintCI() {
   fixture "mod-deps-vendored-with-tests"
 
   dotest
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCaptured "RUN   Test_BasicTest"
   assertCaptured "PASS: Test_BasicTest"
   assertCaptured "/.golangci.{yml,toml,json} detected"
@@ -63,7 +63,7 @@ testModProcfileCreation() {
   assertCaptured "Running: go install -v -tags heroku github.com/heroku/fixture/cmd/web
 github.com/heroku/fixture/cmd/other"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertFile "other: bin/other
 web: bin/web" "Procfile"
 }
@@ -95,14 +95,14 @@ github.com/gorilla/mux
   assertGoInstallOnlyFixturePackageCaptured
 
   # On the second compile go should already be fetched and installed & the packages should be downloaded already.
-  assertNotCaptured "Fetching ${DEFAULT_GO_VERSION}.linux-amd64.tar.gz... done"
+  assertNotCaptured "Fetching ${DEFAULT_GO_VERSION}.linux-amd64.tar.gz"
   assertNotCaptured "Installing ${DEFAULT_GO_VERSION}"
   assertNotCaptured "go: finding github.com/gorilla/mux v1.6.2"
   assertNotCaptured "go: finding github.com/gorilla/context v1.1.1"
   assertNotCaptured "go: downloading github.com/gorilla/mux v1.6.2"
   assertNotCaptured "go: extracting github.com/gorilla/mux v1.6.2"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -116,7 +116,7 @@ testModWithQuotesModule() {
   assertGoInstallCaptured "go1.12.17"
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
   assertFile "web: bin/fixture" "Procfile"
 }
@@ -136,7 +136,7 @@ testModWithNonFilesInBin() {
   assertNotCaptured "go: downloading github.com/gorilla/mux v1.6.2"
   assertNotCaptured "go: extracting github.com/gorilla/mux v1.6.2"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -162,7 +162,7 @@ github.com/heroku/fixture/cmd/other"
   assertFile "fixture: bin/fixture
 other: bin/other" "Procfile"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
   assertCompiledBinaryExists other
 }
@@ -183,7 +183,7 @@ PRE COMPILE"
   assertCaptured "Running bin/go-post-compile hook
 POST COMPILE"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -197,7 +197,8 @@ testModNoVersion() {
   assertGoInstallCaptured
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
+  assertCapturedStderr "does not specify a Go version"
   assertInstalledFixtureBinary
 }
 
@@ -209,7 +210,7 @@ testModOldVersion() {
   compile
   assertCaptured "Detected go modules via go.mod"
   assertCaptured "Detected Module Name: github.com/heroku/fixture"
-  assertCapturedError 1 "Please add/update the comment in your go.mod file to specify a Go version >= go1.11 like so:"
+  assertCapturedError 1 "a Go version >= go1.11 like so:"
 }
 
 testModInstall() {
@@ -231,7 +232,7 @@ github.com/heroku/fixture/other"
 ./bin/fixture2
 ./bin/other"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCompiledBinaryExists "fixture1"
   assertCompiledBinaryExists "fixture2"
   assertCompiledBinaryExists "other"
@@ -247,7 +248,7 @@ testModBasic() {
   assertGoInstallCaptured
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -261,7 +262,7 @@ testModBasicGo111() {
   assertCaptured "Installing go1.11.13"
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -275,7 +276,7 @@ testModBasicGo125() {
   assertCaptured "Installing go1.25"
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -289,7 +290,7 @@ testModBasicGo126() {
   assertCaptured "Installing go1.26"
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -303,7 +304,7 @@ testModBasicWithoutProcfile() {
   assertGoInstallCaptured
   assertGoInstallOnlyFixturePackageCaptured
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
   assertFile "web: bin/fixture" "Procfile"
 }
@@ -395,7 +396,7 @@ testModDepsVendored() {
   assertNotCaptured "go: downloading github.com/gorilla/mux v1.6.2"
   assertNotCaptured "go: extracting github.com/gorilla/mux v1.6.2"
 
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertInstalledFixtureBinary
 }
 
@@ -409,9 +410,9 @@ testModPackageSpecOverride() {
   compile
   assertModulesBoilerplateCaptured
   assertGoInstallCaptured "go1.12.17"
-  assertCaptured "Using \$GO_INSTALL_PACKAGE_SPEC override."
+  assertCapturedStderr "Using \$GO_INSTALL_PACKAGE_SPEC override."
   assertCaptured "Running: go install -v -tags heroku ./cmd/fixture"
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCompiledBinaryExists "fixture"
   assertBuildDirFileDoesNotExist "bin/other"
 }
@@ -425,9 +426,9 @@ testModGOVERSIONOverride() {
 
   compile
   assertCaptured "Installing go1.24"
-  assertCaptured "Using \$GOVERSION override."
+  assertCapturedStderr "Using \$GOVERSION override."
   assertGoInstallOnlyFixturePackageCaptured
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCompiledBinaryExists
 }
 
@@ -453,7 +454,7 @@ testModLDSymbolValue() {
   assertGoInstallCaptured
   assertCaptured "Running: go install -v -tags heroku -ldflags -X main.fixture=fixture"
   assertCaptured "github.com/heroku/fixture"
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCompiledBinaryExists
   assertCompiledBinaryOutputs "fixture" "fixture"
 }
@@ -470,7 +471,7 @@ testModBasicWithTools() {
   assertGoInstallCaptured
   assertGoInstallOnlyFixturePackageCaptured
   assertCaptured "Copying go tool chain to"
-  assertCapturedSuccess
+  assertCapturedExitSuccess
   assertCompiledBinaryExists
   assertBuildDirFileExists ".heroku/go/bin/go"
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -95,7 +95,7 @@ github.com/gorilla/mux
   assertGoInstallOnlyFixturePackageCaptured
 
   # On the second compile go should already be fetched and installed & the packages should be downloaded already.
-  assertNotCaptured "Fetching ${DEFAULT_GO_VERSION}.linux-amd64.tar.gz"
+  assertNotCaptured "Fetching ${DEFAULT_GO_VERSION}"
   assertNotCaptured "Installing ${DEFAULT_GO_VERSION}"
   assertNotCaptured "go: finding github.com/gorilla/mux v1.6.2"
   assertNotCaptured "go: finding github.com/gorilla/context v1.1.1"

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -183,6 +183,10 @@ assertCaptured() {
   assertFileContains "$@" "${STD_OUT}"
 }
 
+assertCapturedStderr() {
+  assertFileContains "$@" "${STD_ERR}"
+}
+
 assertNotCaptured() {
   assertFileNotContains "$@" "${STD_OUT}"
 }
@@ -306,6 +310,6 @@ assertInstalledFixtureBinary() {
 
 assertGoInstallCaptured() {
   local go_ver=${1:-${DEFAULT_GO_VERSION}}
-  assertCaptured "Installing ${go_ver}
-Fetching ${go_ver}.linux-amd64.tar.gz... done"
+  assertCaptured "Installing ${go_ver}"
+  assertCaptured "Fetching ${go_ver}"
 }


### PR DESCRIPTION
Migrate build output from ad-hoc formatting functions to the structured `output::` library (matching the [Python classic buildpack's pattern](https://github.com/heroku/heroku-buildpack-python/blob/main/lib/output.sh)), and indent all command output under its parent step for a cleaner, more consistent build log.

### Changes

- Replace `step`, `info`, `warn`, `err`, `start`/`finished` with `output::step`, `output::indent`, `output::warning`, `output::error`, `output::notice`
- Remove old color constants and function definitions from `lib/common.sh`
- Consolidate multi-line `warn`/`err` call sequences into single heredoc blocks
- Drop the `start`/`finished` "... done" pattern in favor of plain `output::step`
- Pipe command output (`go install`, `go list`, `curl`, `tar`, pre/post compile hooks) through `output::indent`
- Warnings and notices now correctly write to stderr (previously `warn()` and `info()` wrote to stdout)
- Update test assertions for the new output format

GUS-W-21540568

## Example Output

### Before

```
----->
       Detected go modules via go.mod
----->
       Detected Module Name: github.com/heroku/go-getting-started
----->
-----> New Go Version, clearing old cache
-----> Installing go1.25.8
-----> Fetching go1.25.8.linux-amd64.tar.gz... done
-----> Determining packages to install
go: downloading github.com/gin-gonic/gin v1.11.0
go: downloading github.com/heroku/x v0.5.3
go: downloading github.com/quic-go/quic-go v0.54.1
go: downloading golang.org/x/net v0.47.0
       ...

       Detected the following main packages to install:
       		github.com/heroku/go-getting-started

-----> Running: go install -v -tags heroku  github.com/heroku/go-getting-started
internal/goarch
internal/unsafeheader
       ...
github.com/heroku/go-getting-started

       Installed the following binaries:
       		./bin/go-getting-started

       Created a Procfile with the following entries:
       		web: bin/go-getting-started

       If these entries look incomplete or incorrect please create a Procfile with the required entries.
       See https://devcenter.heroku.com/articles/procfile for more details about Procfiles
```

Issues:
- Empty `-----> ` arrows used as spacers
- `info()` messages appear as indented green text rather than step headings
- Module download progress (`go: downloading ...`) is unindented
- `go install -v` compilation output is unindented
- `Fetching ... done` pattern obscures retry information
- Warnings written to stdout instead of stderr

### After

```
-----> Detected go modules via go.mod
-----> Detected Module Name: github.com/heroku/go-getting-started
-----> New Go Version, clearing old cache
-----> Installing go1.25.8
-----> Fetching go1.25.8.linux-amd64.tar.gz
-----> Determining packages to install
       go: downloading github.com/gin-gonic/gin v1.11.0
       go: downloading github.com/heroku/x v0.5.3
       go: downloading github.com/quic-go/quic-go v0.54.1
       go: downloading golang.org/x/net v0.47.0
       ...
-----> Detected the following main packages to install:
       github.com/heroku/go-getting-started
-----> Running: go install -v -tags heroku  github.com/heroku/go-getting-started
       internal/goarch
       internal/unsafeheader
       ...
       github.com/heroku/go-getting-started
-----> Installed the following binaries:
       ./bin/go-getting-started
-----> Created a Procfile with the following entries:
       web: bin/go-getting-started

 !     If these entries look incomplete or incorrect please create a
 !     Procfile with the required entries.
 !     See https://devcenter.heroku.com/articles/procfile for more details about Procfiles
```

### Notes on test changes

**`assertCapturedSuccess` → `assertCapturedExitSuccess`**: Since warnings and notices now write to stderr (previously they went to stdout via `warn()`/`info()`), any test whose build path produces a warning would fail the old `assertCapturedSuccess` check (which asserts empty stderr). All compile-step assertions now use `assertCapturedExitSuccess` (exit code only), with explicit `assertCapturedStderr` calls where we want to verify specific warning content.

**Multi-line `grep -F` assertions**: Several existing test assertions used multi-line needle strings (e.g. `assertCaptured "Installing go1.25\nFetching go1.25.linux-amd64.tar.gz... done"`). These appeared to validate both lines, but `grep -F` treats newlines in the pattern as OR separators — it matches if *any* line is found. This meant assertions like `assertGoInstallCaptured` silently passed on the first line alone ("Installing go1.25" matches "Installing go1.25.8" as a substring), even though the second line ("Fetching go1.25.linux-amd64.tar.gz... done") never matched the actual expanded version. The updated assertions split these into separate calls to make each check explicit.

**`${FLAGS[@]}` → `${FLAGS[*]}` in `output::step`**: The old `step()` function used `$@` which expanded all arguments, but `output::step` uses `${1}` only. Inside double quotes, `${FLAGS[@]}` expands to separate arguments, so `output::step "Running: go install -v ${FLAGS[@]} ${pkgs}"` would truncate after the first flag. Using `${FLAGS[*]}` joins the array into a single string for display, while the actual `go install` command still uses `${FLAGS[@]}` for correct argument splitting.

### Future work

- **Eliminate redundant `go list` calls**: `mainPackagesInModule` runs `go list ./...` to detect main packages, but `go install` then resolves and builds the same packages. For the common auto-detection case (no `// +heroku install` directive), we could skip `go list` entirely and use `go install ./...` instead, deriving Procfile entries from the installed binaries (`binDiff`). This would remove the duplicate module resolution and the `2> >(output::indent >&2)` process substitution workaround.
- **Indent devel version output**: The development Go version build path (`devel-*`) downloads and compiles Go from source. The `curl` download and `./make.bash` compilation output is not piped through `output::indent` — intentionally left for now since this is a rarely-used code path and the compilation output is extensive - and won't be tested anyway as it's not officially supported and slows down test execution substantially.
- **Consistent formatting**: This PR adds heredoc blocks that have to use tabs. We should consider using tabs consistently in files that include heredoc, to avoid mixing tabs and spaces (and start enforcing linting during CI).