### PR TITLE
Remove dead code from `ensureGo` and unused `golangci-lint` inventory entry

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -120,9 +120,6 @@ ensureGo() {
 				goPath="${GO_CACHE_DIR}/${bGoVersion}/go"
 				txt="Installing bootstrap ${bGoVersion}"
 				;;
-			go1)
-				goFile="go.go1.linux-amd64.tar.gz"
-				;;
 			*)
 				goFile="${goVersion}.linux-amd64.tar.gz"
 				;;

--- a/files.json
+++ b/files.json
@@ -923,10 +923,6 @@
     "SHA": "031f088e5d955bab8657ede27ad4e3bc5b7c1ba281f05f245bcc304f327c987a",
     "URL": "https://dl.google.com/go/go1.26.1.linux-amd64.tar.gz"
   },
-  "golangci-lint-1.16.0-linux-amd64.tar.gz": {
-    "SHA": "5343fc3ffcbb9910925f4047ec3c9f2e9623dd56a72a17ac76fb2886abc0976b",
-    "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.16.0/golangci-lint-1.16.0-linux-amd64.tar.gz"
-  },
   "golangci-lint-1.20.0-linux-amd64.tar.gz": {
     "SHA": "5a638cba74fbfb6e11b9dce38e8caf3f18e998b6548118116d631ebcae3ebac5",
     "URL": "https://github.com/golangci/golangci-lint/releases/download/v1.20.0/golangci-lint-1.20.0-linux-amd64.tar.gz"


### PR DESCRIPTION
This PR removes:

- The special `go1` version handing in `ensureGo()` (support for Go `<1.11` was removed in https://github.com/heroku/heroku-buildpack-go/pull/644, and this branch is never reached).
- The unused `golangci-lint-1.16.0-linux-amd64.tar.gz` entry from `files.json` (only 1.20.0 is referenced in `bin/test-compile`).

GUS-W-21598947