### PR TITLE
Remove redundant `--retry-max-time` curl option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Remove redundant `--retry-max-time` curl option
 
 ## [v226] - 2026-03-16
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -10,11 +10,11 @@ FilesJSON="${BUILDPACK_DIR}/files.json"
 # shellcheck disable=SC2154
 goMOD="${BUILD_DIR}/go.mod"
 
-# We use --max-time/--retry-max-time for improved UX and metrics for hanging downloads compared to
-# seconds relying on the build system timeout. Go tarballs are up to ~70 MB and typically download in a few
-# seconds on Heroku, so we set relatively low timeouts to reduce delays before retries.
+# We use --max-time for improved UX and metrics for hanging downloads compared to relying on the
+# build system timeout. Go tarballs are up to ~70 MB and typically download in a few seconds on
+# Heroku, so we set relatively low timeouts to reduce delays before retries.
 # We use --no-progress-meter rather than --silent so that retry status messages are printed.
-CURL="curl --no-progress-meter --location --fail --max-time 30 --retry-max-time 200 --retry 5 --retry-connrefused --connect-timeout 5"
+CURL="curl --no-progress-meter --location --fail --max-time 30 --retry 5 --retry-connrefused --connect-timeout 5"
 
 TOOL=""
 # Default to $SOURCE_VERSION environment variable: https://devcenter.heroku.com/articles/buildpack-api#bin-compile


### PR DESCRIPTION
The total retry time is already bounded by `--max-time 30` and `--retry 5`, making `--retry-max-time` unnecessary.

GUS-W-21608461