### PR TITLE
Add curl timeouts and retries to sbin/add-version metadata fetch

### DIFF
--- a/sbin/add-version
+++ b/sbin/add-version
@@ -13,7 +13,19 @@ fi
 # Fetch the release metadata once. go.dev serves the sha256 for each file
 # inline in this JSON; the per-file `<tarball>.sha256` endpoint is not served
 # from go.dev (it redirects to the docs page), so we source checksums here.
-if ! releases="$(curl -s -f "https://go.dev/dl/?mode=json&include=all")"; then
+# The curl flags mirror sbin/update-go-versions: --no-progress-meter (rather
+# than -s) keeps retry status messages visible, and the timeouts/retries stop a
+# transient go.dev blip from failing the run and delaying updates until the next
+# daily cron.
+if ! releases="$(curl \
+	--no-progress-meter \
+	--fail \
+	--connect-timeout 3 \
+	--max-time 60 \
+	--retry 5 \
+	--retry-max-time 60 \
+	--retry-connrefused \
+	'https://go.dev/dl/?mode=json&include=all')"; then
 	echo "error: adding ${V}: couldn't fetch release metadata from go.dev" >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

- Follow-up to #679 addressing [this review comment](https://github.com/heroku/heroku-buildpack-go/pull/679#discussion_r3673795151): the go.dev metadata `curl` in `sbin/add-version` used `-s -f`, which silenced errors and had no timeouts or retries.
- Replace it with the same resilient invocation already used in `sbin/update-go-versions`: `--no-progress-meter` (instead of `-s`, so retry status messages stay visible) plus connection/overall timeouts and retries (`--connect-timeout`, `--max-time`, `--retry`, `--retry-max-time`, `--retry-connrefused`).
- Without this, a transient go.dev blip fails the run and delays Go updates until the next daily cron.

> Note: based on the `switch-inventory-to-go-dev` branch since the go.dev `curl` line only exists there; will auto-retarget to `main` once #679 merges.

GUS-W-23636866
