### PR TITLE
Ignore `capability[]` and `state[]` in the git credential helper

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -226,9 +226,9 @@ setGitCredHelper() {
                         password="${value}"
                     ;;
                     wwwauth[]|capability[]|state[])
-                        # Informational fields (git 2.44+/2.46+); the
-                        # credential-helper protocol requires ignoring
-                        # unrecognized attributes.
+                        # Informational fields:
+                        # - wwwauth[] (git 2.41+)
+                        # - capability[] / state[] (git 2.46+)
                         :
                     ;;
                     *)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -225,7 +225,10 @@ setGitCredHelper() {
                     password)
                         password="${value}"
                     ;;
-                    wwwauth[])
+                    wwwauth[]|capability[]|state[])
+                        # Informational fields (git 2.44+/2.46+); the
+                        # credential-helper protocol requires ignoring
+                        # unrecognized attributes.
                         :
                     ;;
                     *)


### PR DESCRIPTION
Fixes #683.

git 2.46+ sends `capability[]=authtype` (and optionally `state[]`) to credential helpers as part of the credential-protocol capabilities handshake. The helper's attribute parser hard-fails on unrecognized keys, which breaks every `GO_GIT_CRED__*`-authenticated private repo fetch on stacks with newer git (heroku-26):

```
Unsupported key: capability[]=authtype
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The git-credential documentation requires helpers to ignore unrecognized attributes. This change treats `capability[]` and `state[]` the same as the already-tolerated `wwwauth[]`.

Tested by pointing an app on heroku-26 with a private Go module dependency at this branch: the previously failing build fetches the module and deploys successfully; without the patch the same configuration fails as above.