### PR TITLE
Ignore `capability[]` and `state[]` in the git credential helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add support for capability[] and state[] git credential arguments
 
 ## [v233] - 2026-08-14
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -226,9 +226,9 @@ setGitCredHelper() {
                         password="${value}"
                     ;;
                     wwwauth[]|capability[]|state[])
-                        # Informational fields (git 2.44+/2.46+); the
-                        # credential-helper protocol requires ignoring
-                        # unrecognized attributes.
+                        # Informational fields:
+                        # - wwwauth[] (git 2.41+)
+                        # - capability[] / state[] (git 2.46+)
                         :
                     ;;
                     *)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -225,7 +225,10 @@ setGitCredHelper() {
                     password)
                         password="${value}"
                     ;;
-                    wwwauth[])
+                    wwwauth[]|capability[]|state[])
+                        # Informational fields (git 2.44+/2.46+); the
+                        # credential-helper protocol requires ignoring
+                        # unrecognized attributes.
                         :
                     ;;
                     *)

--- a/test/run.sh
+++ b/test/run.sh
@@ -328,6 +328,52 @@ testModPrivateProxy() {
 	assertInstalledFixtureBinary
 }
 
+# Regression test for #683: git >= 2.46 announces `capability[]=authtype` to
+# credential helpers (and can follow with `state[]`) when it authenticates over
+# HTTP. The helper installed by setGitCredHelper must ignore these the same way it
+# already ignores `wwwauth[]`; before the fix it hit the catch-all `case` branch
+# and died with "Unsupported key: capability[]=authtype" before ever returning
+# credentials, breaking every private-repo fetch on stacks shipping git >= 2.46.
+#
+# We drive the installed helper directly — the same way git does: `sh -c "<body>
+# get"` with the request attributes on stdin, each newline-terminated and closed
+# with EOF. This exercises the exact parser that regressed, with a fixed input
+# matching git's documented credential-helper protocol, rather than depending on
+# `git credential fill` to relay a caller-injected capability (which the CLI path
+# does not announce on its own, so such a test could silently stop reproducing).
+testGitCredHelperIgnoresCapabilityAttributes() {
+	echo "fake-token" >"${ENV_DIR}/GO_GIT_CRED__HTTPS__GITHUB__COM"
+
+	# Run in a subprocess with an isolated HOME: common.sh enables `set -euo
+	# pipefail` at source time and setGitCredHelper installs the helper via `git
+	# config --global`, neither of which should leak into the test runner or other
+	# tests. `command env` bypasses the `env` test helper defined in test/utils.sh.
+	# shellcheck disable=SC2016 # the single-quoted body is expanded by the inner bash, not here
+	capture command env \
+		BUILDPACK_DIR="${BUILDPACK_HOME}" \
+		BUILD_DIR="${BUILD_DIR}" \
+		ENV_DIR="${ENV_DIR}" \
+		HOME="${OUTPUT_DIR}/githome" \
+		bash -c '
+			set -euo pipefail
+			mkdir -p "${HOME}"
+			# shellcheck disable=SC1091
+			source "${BUILDPACK_DIR}/lib/common.sh"
+			setGitCredHelper "${ENV_DIR}"
+			# git stores a shell helper prefixed with "!" and invokes it as
+			# `sh -c "<body> <operation>"`; strip the "!" and do the same.
+			helper="$(git config --global credential.helper)"
+			printf "capability[]=authtype\nprotocol=https\nhost=github.com\nstate[]=helper:0\n" \
+				| sh -c "${helper#!} get"
+		'
+
+	assertCapturedExitSuccess
+	assertCaptured "username=fake-token"
+	assertCaptured "password=fake-token"
+	assertCapturedStderr "Using credentials from GO_GIT_CRED__HTTPS__GITHUB__COM"
+	assertFileNotContains "Unsupported key" "${STD_ERR}"
+}
+
 testModDeps() {
 	fixture "mod-deps"
 


### PR DESCRIPTION
Supersedes #684, which was missing some key details (CHANGELOG entry, regression test) that I was not able to commit to the original PR so they are added here. @patjakubik's original commit is preserved for attribution.

From #684:

> git 2.46+ sends `capability[]=authtype` (and optionally `state[]`) to credential helpers as part of the credential-protocol capabilities handshake. The helper's attribute parser hard-fails on unrecognized keys, which breaks every `GO_GIT_CRED__*`-authenticated private repo fetch on stacks with newer git (heroku-26):
>
> ```
> Unsupported key: capability[]=authtype
> fatal: could not read Username for 'https://github.com': terminal prompts disabled
> ```
>
> The git-credential documentation requires helpers to ignore unrecognized attributes. This change treats `capability[]` and `state[]` the same as the already-tolerated `wwwauth[]`.
>
> Tested by pointing an app on heroku-26 with a private Go module dependency at this branch: the previously failing build fetches the module and deploys successfully; without the patch the same configuration fails as above.

Fixes #683, W-23924668
